### PR TITLE
Allow manual deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Currently, you can't manually deploy the webpages workflow. This PR fixes that by adding the `workflow_dispatch` hook.