### PR TITLE
Implement `some`

### DIFF
--- a/.changeset/lucky-pans-talk.md
+++ b/.changeset/lucky-pans-talk.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Adds support for the `some` matcher

--- a/.changeset/weak-cows-speak.md
+++ b/.changeset/weak-cows-speak.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Fixed an issue with `err` not throwing whenever the underlying function didn't throw

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -70,6 +70,8 @@ export interface Assertion<T = unknown> {
     _self: this;
     size(size: number): this;
     sizeOf(size: number): this;
+    some(condition: Filter<InferArrayElement<T>>): this;
+    some(reason: string, condition: Filter<InferArrayElement<T>>): this;
     readonly still: this;
     string(): Assertion<string>;
     substring(str: string): Assertion<T>;
@@ -177,6 +179,9 @@ export function extendNegations(methods: ReadonlyArray<string>): void;
 
 // @public
 export function extendNOPs(methods: ReadonlyArray<string>): void;
+
+// @public
+export type Filter<T = unknown> = (value: T) => boolean;
 
 // @public
 export function getDefaultExpectConfig(): ExpectConfig;

--- a/src/expect/extensions/any-of/index.spec.ts
+++ b/src/expect/extensions/any-of/index.spec.ts
@@ -53,9 +53,9 @@ export = () => {
     it("works with paths", () => {
       err(() => {
         withProxy(TEST_SON, (p) => {
-          expect(p.age).to.be.anyOf([1, 2, 3, 4]);
+          expect(p.age).to.be.anyOf([1, 2, 3]);
         });
-      }, "Expected age to be any of '[1,2,3,4]'");
+      }, "Expected age to be any of '[1,2,3]'");
     });
 
     it("uses enum values", () => {

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -26,5 +26,6 @@ import "./instance-of";
 import "./length";
 import "./negations";
 import "./noops";
+import "./some";
 import "./substring";
 import "./throws";

--- a/src/expect/extensions/some/index.spec.ts
+++ b/src/expect/extensions/some/index.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { startsWith } from "@rbxts/string-utils";
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("some", () => {
+    it("checks if the array has some element", () => {
+      expect([1, 2, 3])
+        .to.have.some((it) => it === 2)
+        .but.not.some((it) => it === 4);
+
+      expect([1, 2, 3])
+        .to.have.some("equals two", (it) => it === 2)
+        .but.not.some("equals four", (it) => it === 4);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws if the check fails", () => {
+      err(() => {
+        expect([1, 2]).to.have.some((it) => it === 3);
+      }, `Expected '[1,2]' to have at least one element that passes some check`);
+
+      err(
+        () => {
+          expect([1, 2]).to.not.have.some((it) => it === 2);
+        },
+        `Expected '[1,2]' to NOT have any elements that passes some check, but it did at index '2'`,
+        "Value of [2]: '2'"
+      );
+    });
+
+    it("throws if the check fails, with the provided reason", () => {
+      err(() => {
+        expect([1, 2]).to.have.some("equals 3", (it) => it === 3);
+      }, `Expected '[1,2]' to have at least one element that equals 3`);
+
+      err(
+        () => {
+          expect([1, 2]).to.not.have.some("equal 2", (it) => it === 2);
+        },
+        `Expected '[1,2]' to NOT have any elements that equal 2, but it did at index '2'`,
+        "Value of [2]: '2'"
+      );
+    });
+
+    it("throws if the value is undefined", () => {
+      err(() => {
+        expect(undefined as unknown as unknown[]).to.have.some(() => true);
+      }, `Expected the value to have at least one element that passes some check, but it was undefined`);
+
+      err(() => {
+        expect(undefined as unknown as unknown[]).to.have.some(
+          "likes pizza",
+          () => true
+        );
+      }, `Expected the value to have at least one element that likes pizza, but it was undefined`);
+    });
+
+    it("throws if the value is not an array", () => {
+      err(() => {
+        expect(5 as unknown as unknown[]).to.have.some(() => true);
+      }, `Expected '5' to have at least one element that passes some check, but it wasn't an array`);
+
+      err(() => {
+        expect(5 as unknown as unknown[]).to.have.some(
+          "likes pizza",
+          () => true
+        );
+      }, `Expected '5' to have at least one element that likes pizza, but it wasn't an array`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.have.some(() => false);
+          });
+        },
+        "Expected parent.cars to have at least one element that passes some check",
+        `parent.cars: '["Tesla","Civic"]'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.not.have.some(
+              `start with "Civ"`,
+              (it) => startsWith(it, "Civ")
+            );
+          });
+        },
+        `Expected parent.cars to NOT have any elements that start with "Civ", but it did at index '2'`,
+        `parent.cars: '["Tesla","Civic"]'`,
+        `Value of [2]: "Civic"`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/some/index.ts
+++ b/src/expect/extensions/some/index.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable roblox-ts/no-array-pairs */
+
+import { Filter } from "@rbxts/expect";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+import { isArray } from "@src/util/object";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to have at least one element that ${place.reason}`,
+  `Expected ${place.name} to ${place.not} have any elements that ${place.reason}`
+)
+  .reason("passes some check")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+const some: CustomMethodImpl<unknown[]> = (
+  source,
+  actual,
+  reasonOrCallback: string | Filter,
+  maybeCallback?: Filter
+) => {
+  const message = baseMessage.use();
+
+  if (typeIs(reasonOrCallback, "string")) {
+    message.reason(reasonOrCallback);
+  }
+
+  if (actual === undefined) {
+    return message
+      .name("the value")
+      .trailingFailureSuffix(", but it was undefined")
+      .fail();
+  }
+
+  const actualIsArray = source.is_array ?? isArray(actual);
+  if (!actualIsArray)
+    return message.trailingFailurePrefix(", but it wasn't an array").fail();
+
+  const callback = (maybeCallback ?? reasonOrCallback) as Filter;
+
+  for (const [index, value] of ipairs(actual)) {
+    const result = callback(value as never);
+
+    if (result) {
+      return message
+        .negationSuffix(`, but it did at index '${index}'`)
+        .metadata({ [`Value of [${index}]`]: message.encode(value) })
+        .pass();
+    }
+  }
+
+  return message.fail();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that at least one element in the array satisfies the specified {@link Filter}.
+     *
+     * @param condition - A callback that returns `true` whenever the condition is met.
+     *
+     * @example
+     * ```ts
+     * expect(["Daymon", "Bryan"]).to.have.some(it => startsWith(it, "Bry"));
+     * expect([1,3,5]).to.not.have.some(it => it % 2 === 0);
+     * ```
+     *
+     * @public
+     */
+    some(condition: Filter<T>): this;
+
+    /**
+     * Asserts that at least one element in the array satisfies the specified {@link Filter}.
+     *
+     * @param reason - A {@link Placeholder.reason | reason} to add at the end of the message for additional context.
+     * @param condition - A callback that returns `true` whenever the condition is met.
+     *
+     * @example
+     * ```ts
+     * expect(["Daymon", "Bryan"]).to.have.some("starts with bry", it => startsWith(it, "Bry"));
+     * expect([1,3,5]).to.not.have.some("are even", it => it % 2 === 0);
+     * ```
+     *
+     * Example message:
+     * ```logs
+     * Expected '[1,2,3]' to NOT have any elements that are even, but it did at index '2'
+     *
+     * Value of [2]: '2'
+     * ```
+     *
+     * @public
+     */
+    some(reason: string, condition: Filter<T>): this;
+  }
+}
+
+extendMethods({
+  some: some,
+});

--- a/src/expect/extensions/some/index.ts
+++ b/src/expect/extensions/some/index.ts
@@ -17,7 +17,7 @@
 
 /* eslint-disable roblox-ts/no-array-pairs */
 
-import { Filter } from "@rbxts/expect";
+import type { Filter } from "@rbxts/expect";
 import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
 import { ExpectMessageBuilder } from "@src/message";
 import { place } from "@src/message/placeholders";
@@ -86,7 +86,7 @@ declare module "@rbxts/expect" {
      *
      * @public
      */
-    some(condition: Filter<T>): this;
+    some(condition: Filter<InferArrayElement<T>>): this;
 
     /**
      * Asserts that at least one element in the array satisfies the specified {@link Filter}.
@@ -109,7 +109,7 @@ declare module "@rbxts/expect" {
      *
      * @public
      */
-    some(reason: string, condition: Filter<T>): this;
+    some(reason: string, condition: Filter<InferArrayElement<T>>): this;
   }
 }
 

--- a/src/expect/index.ts
+++ b/src/expect/index.ts
@@ -38,6 +38,7 @@ export {
 export {
   Assertion,
   EnumValue,
+  Filter,
   InferArrayElement,
   LuaEnum,
   TypeCheckCallback,

--- a/src/expect/types/index.ts
+++ b/src/expect/types/index.ts
@@ -111,6 +111,18 @@ export interface Assertion<T = unknown> {
 export type InferArrayElement<T> = T extends (infer U)[] ? U : never;
 
 /**
+ * Callback for deciding if a `value` satisfies a condition.
+ *
+ * @example
+ * ```ts
+ * const isEven: Filter<number[]> = (value) => value % 2 === 0;
+ * ```
+ *
+ * @public
+ */
+export type Filter<T = unknown> = (value: InferArrayElement<T>) => boolean;
+
+/**
  * Callback for deciding if a `value` matches a given type `T`.
  *
  * @remarks

--- a/src/expect/types/index.ts
+++ b/src/expect/types/index.ts
@@ -115,12 +115,12 @@ export type InferArrayElement<T> = T extends (infer U)[] ? U : never;
  *
  * @example
  * ```ts
- * const isEven: Filter<number[]> = (value) => value % 2 === 0;
+ * const isEven: Filter<number> = (value) => value % 2 === 0;
  * ```
  *
  * @public
  */
-export type Filter<T = unknown> = (value: InferArrayElement<T>) => boolean;
+export type Filter<T = unknown> = (value: T) => boolean;
 
 /**
  * Callback for deciding if a `value` matches a given type `T`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   EnumValue,
   ExpectConfig,
   ExpectMethodResult,
+  Filter,
   InferArrayElement,
   LuaEnum,
   TypeCheckCallback,

--- a/src/util/tests.ts
+++ b/src/util/tests.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Assertion } from "@rbxts/expect";
+import { Result } from "@rbxts/rust-classes";
 import { includes } from "@rbxts/string-utils";
 import type { ExpectMessageBuilder } from "@src/message";
 
@@ -130,19 +131,19 @@ export const TEST_SON: Person = {
  * @public
  */
 export function err(callback: () => unknown, ...messages: string[]) {
-  try {
-    callback();
-
-    throw `The function did not throw a message.
+  Result.fromVoidCallback(callback).match(
+    () => {
+      throw `The function did not throw a message.
   
-  Expected Messages:
-  ${messages.join("\n")}
-`;
-  } catch (e) {
-    const m = e as string;
-    for (const message of messages) {
-      if (!includes(m, message)) {
-        throw `The function threw with the wrong message.
+    Expected Messages:
+    ${messages.join("\n")}
+  `;
+    },
+    (err) => {
+      const m = err.unwrap() as string;
+      for (const message of messages) {
+        if (!includes(m, message)) {
+          throw `The function threw with the wrong message.
 
   Expected Message:
   ${message}
@@ -150,7 +151,8 @@ export function err(callback: () => unknown, ...messages: string[]) {
   Actual Message:
   ${m}
       `;
+        }
       }
     }
-  }
+  );
 }

--- a/src/util/tests.ts
+++ b/src/util/tests.ts
@@ -72,7 +72,9 @@ export const TEST_SON: Person = {
  *   expect([1]).to.be.empty();
  * });
  * ```
+ *
  * Output:
+ *
  * ```logs
  * The function did not throw a message.
  * ```
@@ -83,7 +85,9 @@ export const TEST_SON: Person = {
  *   expect([1]).to.be.empty();
  * }, `Expected '[1]' to be empty, but it had an element`);
  * ```
+ *
  * Output if the string(s) weren't found in the error:
+ *
  * ```logs
  * The function threw with the wrong message.
  *
@@ -93,7 +97,9 @@ export const TEST_SON: Person = {
  *   Actual Message:
  *   Expected '[1]' to be empty, but it had the element '1'
  * ```
+ *
  * Output if the function didn't throw at all:
+ *
  * ```logs
  * The function did not throw a message.
  *
@@ -110,6 +116,7 @@ export const TEST_SON: Person = {
  *
  * If it doesn't find any of the provided substrings, it will
  * throw with that specific substring:
+ *
  * ```logs
  * The function threw with the wrong message.
  *

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -893,6 +893,28 @@ Asserts that the value has a length of `size`<!-- -->.
 </td></tr>
 <tr><td>
 
+[some(condition)](./expect.assertion.some.md)
+
+
+</td><td>
+
+Asserts that at least one element in the array satisfies the specified [Filter](./expect.filter.md)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[some(reason, condition)](./expect.assertion.some_1.md)
+
+
+</td><td>
+
+Asserts that at least one element in the array satisfies the specified [Filter](./expect.filter.md)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [string()](./expect.assertion.string.md)
 
 

--- a/wiki/docs/api/expect.assertion.some.md
+++ b/wiki/docs/api/expect.assertion.some.md
@@ -1,0 +1,64 @@
+---
+id: expect.assertion.some
+title: Assertion.some() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [some](./expect.assertion.some.md)
+
+## Assertion.some() method
+
+Asserts that at least one element in the array satisfies the specified [Filter](./expect.filter.md)<!-- -->.
+
+**Signature:**
+
+```typescript
+some(condition: Filter<InferArrayElement<T>>): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+condition
+
+
+</td><td>
+
+[Filter](./expect.filter.md)<!-- -->&lt;[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;&gt;
+
+
+</td><td>
+
+A callback that returns `true` whenever the condition is met.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect(["Daymon", "Bryan"]).to.have.some(it => startsWith(it, "Bry"));
+expect([1,3,5]).to.not.have.some(it => it % 2 === 0);
+```

--- a/wiki/docs/api/expect.assertion.some_1.md
+++ b/wiki/docs/api/expect.assertion.some_1.md
@@ -1,0 +1,87 @@
+---
+id: expect.assertion.some_1
+title: Assertion.some() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [some](./expect.assertion.some_1.md)
+
+## Assertion.some() method
+
+Asserts that at least one element in the array satisfies the specified [Filter](./expect.filter.md)<!-- -->.
+
+**Signature:**
+
+```typescript
+some(reason: string, condition: Filter<InferArrayElement<T>>): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+reason
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+A [reason](./expect.placeholder.reason.md) to add at the end of the message for additional context.
+
+
+</td></tr>
+<tr><td>
+
+condition
+
+
+</td><td>
+
+[Filter](./expect.filter.md)<!-- -->&lt;[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;&gt;
+
+
+</td><td>
+
+A callback that returns `true` whenever the condition is met.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect(["Daymon", "Bryan"]).to.have.some("starts with bry", it => startsWith(it, "Bry"));
+expect([1,3,5]).to.not.have.some("are even", it => it % 2 === 0);
+```
+Example message:
+
+```logs
+Expected '[1,2,3]' to NOT have any elements that are even, but it did at index '2'
+
+Value of [2]: '2'
+```

--- a/wiki/docs/api/expect.filter.md
+++ b/wiki/docs/api/expect.filter.md
@@ -1,0 +1,24 @@
+---
+id: expect.filter
+title: Filter type
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Filter](./expect.filter.md)
+
+## Filter type
+
+Callback for deciding if a `value` satisfies a condition.
+
+**Signature:**
+
+```typescript
+type Filter<T = unknown> = (value: T) => boolean;
+```
+
+## Example
+
+
+```ts
+const isEven: Filter<number> = (value) => value % 2 === 0;
+```

--- a/wiki/docs/api/expect.md
+++ b/wiki/docs/api/expect.md
@@ -411,6 +411,17 @@ The result of an [expect()](./expect.expect.md) method call.
 </td></tr>
 <tr><td>
 
+[Filter](./expect.filter.md)
+
+
+</td><td>
+
+Callback for deciding if a `value` satisfies a condition.
+
+
+</td></tr>
+<tr><td>
+
 [InferArrayElement](./expect.inferarrayelement.md)
 
 

--- a/wiki/docs/matchers/arrays.mdx
+++ b/wiki/docs/matchers/arrays.mdx
@@ -171,11 +171,20 @@ Extra Elements: '[2]'
 
 ### Some
 
-:::info
+You can use the [some](/docs/api/expect.assertion.some.md) method to check if an array passes some condition.
 
-[GitHub Issue #1](https://github.com/daymxn/rbxts-expect/issues/1)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect([1, 2, 3]).to.have.some((it) => it % 2 === 0);
+expect(["Daymon", "Bryan"]).to.have.some(`starts with "Bry"`, (it) => startsWith(it, "Bry"));
+```
+
+#### Example error
+
+```logs
+Expected '["Byron", "Bryan"]' to have atleast one element that starts with "Day"
+```
 
 ### Contain exactly
 


### PR DESCRIPTION
Adds support for the matcher `some` and fixes an issue with `err` not properly throwing whenever the underlying function didn't.

Fixes #1 