### PR TITLE
Only deploy wiki during releases

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,12 +2,9 @@ name: Deploy to GitHub Pages
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - "wiki/**"
-      - "api/**"
+  release:
+    types:
+      - published
 
 defaults:
   run:


### PR DESCRIPTION
To avoid the wiki accidentally updating with new features before they're released, I've updated the workflow to only run whenever a release is published instead of whenever a commit to main is made.