### PR TITLE
Add `containExactly` and `containExactlyInOrder` matchers

### DIFF
--- a/.changeset/heavy-penguins-drum.md
+++ b/.changeset/heavy-penguins-drum.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Added support for the `containExactly` matcher

--- a/.changeset/lucky-pans-talk.md
+++ b/.changeset/lucky-pans-talk.md
@@ -2,4 +2,4 @@
 "@rbxts/expect": patch
 ---
 
-Adds support for the `some` matcher
+Added support for the `some` matcher

--- a/.changeset/metal-insects-behave.md
+++ b/.changeset/metal-insects-behave.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Fixed an issue preventing `encode` from properly encoding null values

--- a/.changeset/smart-frogs-vanish.md
+++ b/.changeset/smart-frogs-vanish.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Added support for the `containExactlyInOrder` matcher

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -32,6 +32,10 @@ export interface Assertion<T = unknown> {
     readonly been: this;
     boolean(): Assertion<boolean>;
     readonly but: this;
+    containExactly(expectedValues: InferArrayElement<T>[]): this;
+    containExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
+    containsExactly(expectedValues: InferArrayElement<T>[]): this;
+    containsExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
     deepEqual<R = T>(expectedValue: R): Assertion<R>;
     deepEquals<R = T>(expectedValue: R): Assertion<R>;
     readonly does: this;

--- a/src/expect/extensions/contain-exactly-in-order/index.spec.ts
+++ b/src/expect/extensions/contain-exactly-in-order/index.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("containExactlyInOrder", () => {
+    it("checks if two arrays contain the same values, and in the same order", () => {
+      expect([1, 2, 3])
+        .to.containExactlyInOrder([1, 2, 3])
+        .but.not.containExactlyInOrder([1, 2, 3, 4])
+        .or.containExactlyInOrder([1, 2])
+        .or.containExactlyInOrder([1, 3, 2]);
+    });
+
+    it("does deep comparisons", () => {
+      expect([
+        new Vector3(1, 2, 3),
+        new Vector3(3, 2, 1),
+      ]).to.containExactlyInOrder([new Vector3(1, 2, 3), new Vector3(3, 2, 1)]);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws if there are elements missing", () => {
+      err(
+        () => {
+          expect([1, 2]).to.containExactlyInOrder([1, 2, 3]);
+        },
+        `Expected '[1,2]' to contain exactly '[1,2,3]', but it was missing elements`,
+        "Missing elements: '[3]'"
+      );
+    });
+
+    it("throws if there are extra elements", () => {
+      err(
+        () => {
+          expect([1, 2, 3]).to.containExactlyInOrder([1, 2]);
+        },
+        `Expected '[1,2,3]' to contain exactly '[1,2]', but it had an extra element`,
+        "Extra element: '3'"
+      );
+    });
+
+    it("throws if the elements have different values", () => {
+      err(
+        () => {
+          expect([1, 2, 3]).to.containExactlyInOrder([1, 3, 2]);
+        },
+        `Expected '[1,2,3]' to contain exactly '[1,3,2]', but it had a different value for the element at '[1]'`,
+        "Actual [1]: '2'",
+        "Expected [1]: '3'"
+      );
+    });
+
+    it("throws if the elements have different types", () => {
+      err(
+        () => {
+          expect([1, "2", 3]).to.containExactlyInOrder([1, 2, 3]);
+        },
+        `Expected '[1,"2",3]' to contain exactly '[1,2,3]', but it had a different type of element at '[1]`,
+        `Actual [1]: "2" (string)`,
+        `Expected [1]: '2' (number)`
+      );
+    });
+
+    it("throws if the elements have different reference values", () => {
+      err(
+        () => {
+          expect([1, new Instance("Part"), 3]).to.containExactlyInOrder([
+            1,
+            new Instance("Part"),
+            3,
+          ]);
+        },
+        `Expected '[1,null,3]' to contain exactly '[1,null,3]', but it had a different reference for the element at '[1]' (Instance)`,
+        "Actual [1]: 'Part'",
+        "Expected [1]: 'Part'"
+      );
+    });
+
+    it("throws if the value is undefined", () => {
+      err(() => {
+        expect(undefined as unknown as unknown[]).to.containExactlyInOrder([1]);
+      }, `Expected the value to contain exactly '[1]', but it was undefined`);
+    });
+
+    it("throws if the value is not an array", () => {
+      err(() => {
+        expect(5 as unknown as unknown[]).to.containExactlyInOrder([1]);
+      }, `Expected '5' (number) to contain exactly '[1]', but it wasn't an array`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.containExactlyInOrder(["Tesla"]);
+          });
+        },
+        `Expected parent.cars to contain exactly '["Tesla"]', but it had an extra element`,
+        `parent.cars: '["Tesla","Civic"]'`,
+        `Extra element: "Civic"`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/contain-exactly-in-order/index.ts
+++ b/src/expect/extensions/contain-exactly-in-order/index.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deepEqual, FailureType } from "@rbxts/deep-equal";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} contain exactly ${place.expected.value}`
+)
+  .trailingFailurePrefix(`, but it ${place.reason}`)
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+const containExactlyInOrder: CustomMethodImpl<unknown[]> = (
+  _,
+  actual,
+  expectedValue: defined[]
+) => {
+  const message = baseMessage.use().expectedValue(expectedValue);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (typeOf(actual) !== "table") {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't an array");
+  }
+
+  const result = deepEqual(actual, expectedValue, {
+    checkRightMissing: true,
+    inOrder: true,
+  });
+
+  if (result) {
+    switch (result.failType) {
+      case FailureType.DIFFERENT_TYPES: {
+        if (result.rightValue === undefined) {
+          return message
+            .metadata({
+              ["Extra element"]: message.encode(result.leftValue),
+            })
+            .failWithReason("had an extra element");
+        }
+
+        return message
+          .metadata({
+            [`Expected ${result.path}`]: `${message.encode(result.rightValue)} (${result.rightType})`,
+            [`Actual ${result.path}`]: `${message.encode(result.leftValue)} (${result.leftType})`,
+          })
+          .failWithReason(
+            `had a different type of element at '${result.path}'`
+          );
+      }
+      case FailureType.DIFFERENT_REFERENCE: {
+        return message
+          .metadata({
+            [`Expected ${result.path}`]: message.encode(result.rightValue),
+            [`Actual ${result.path}`]: message.encode(result.leftValue),
+          })
+          .failWithReason(
+            `had a different reference for the element at '${result.path}' (${result.leftType})`
+          );
+      }
+      case FailureType.MISSING_ARRAY_VALUE: {
+        if (!result.leftMissing.isEmpty()) {
+          return message
+            .metadata({
+              ["Missing elements"]: message.encode(result.leftMissing),
+            })
+            .failWithReason("was missing elements");
+        } else {
+          return message
+            .metadata({
+              ["Extra elements"]: message.encode(result.rightMissing),
+            })
+            .failWithReason("had extra elements");
+        }
+      }
+      default: {
+        if (result.leftValue === undefined) {
+          return message
+            .metadata({
+              [`Missing element`]: message.encode(result.rightValue),
+            })
+            .failWithReason(`was missing an element`);
+        } else if (result.rightValue === undefined) {
+          return message
+            .metadata({
+              [`Extra element`]: message.encode(result.leftValue),
+            })
+            .failWithReason(`had an extra element`);
+        } else {
+          return message
+            .metadata({
+              [`Expected ${result.path}`]: message.encode(result.rightValue),
+              [`Actual ${result.path}`]: message.encode(result.leftValue),
+            })
+            .failWithReason(
+              `had a different value for the element at '${result.path}'`
+            );
+        }
+      }
+    }
+  }
+
+  return message.pass();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the array contains all of the values in `expectedValues`,
+     * with nothing more or less, and in the same order.
+     *
+     * @remarks
+     * There shouldn't be any extra elements in the actual array;
+     * both arrays should **deeply** contain the same elements, and in the same order.
+     *
+     * @param expectedValues - An array of elements that the actual array should be.
+     *
+     * @example
+     * ```ts
+     * expect([1,2,3]).to.containExactlyInOrder([1,2,3]);
+     * expect([1,2,3]).to.not.containExactlyInOrder([1,3,2]);
+     * ```
+     *
+     * @public
+     */
+    containExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
+
+    /**
+     * Asserts that the array contains all of the values in `expectedValues`,
+     * with nothing more or less, and in the same order.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.containExactlyInOrder | containExactlyInOrder}._
+     *
+     * @public
+     */
+    containsExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
+  }
+}
+
+extendMethods({
+  containExactlyInOrder: containExactlyInOrder,
+  containsExactlyInOrder: containExactlyInOrder,
+});

--- a/src/expect/extensions/contain-exactly/index.spec.ts
+++ b/src/expect/extensions/contain-exactly/index.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("containExactly", () => {
+    it("checks if two arrays contain the same values", () => {
+      expect([1, 2, 3])
+        .to.containExactly([1, 2, 3])
+        .but.not.containExactly([1, 2, 3, 4])
+        .or.containExactly([1, 2]);
+    });
+
+    it("doesn't care about order", () => {
+      expect([1, 2, 3]).to.containExactly([2, 1, 3]);
+    });
+
+    it("does deep comparisons", () => {
+      expect([new Vector3(1, 2, 3), new Vector3(3, 2, 1)]).to.containExactly([
+        new Vector3(3, 2, 1),
+        new Vector3(1, 2, 3),
+      ]);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws if there are elements missing", () => {
+      err(
+        () => {
+          expect([1, 2]).to.containExactly([1, 2, 3]);
+        },
+        `Expected '[1,2]' to contain exactly '[1,2,3]', but it was missing elements`,
+        "Missing elements: '[3]'"
+      );
+    });
+
+    it("throws if there are extra elements", () => {
+      err(
+        () => {
+          expect([1, 2, 3]).to.containExactly([1, 2]);
+        },
+        `Expected '[1,2,3]' to contain exactly '[1,2]', but it had extra elements`,
+        "Extra elements: '[3]'"
+      );
+    });
+
+    it("throws if there are missing and extra elements", () => {
+      err(
+        () => {
+          expect([1, 2]).to.containExactly([1, 3]);
+        },
+        `Expected '[1,2]' to contain exactly '[1,3]', but it was elements missing and it had extra elements`,
+        "Extra elements: '[2]'",
+        "Missing elements: '[3]'"
+      );
+    });
+
+    it("throws if the value is undefined", () => {
+      err(() => {
+        expect(undefined as unknown as unknown[]).to.containExactly([1]);
+      }, `Expected the value to contain exactly '[1]', but it was undefined`);
+    });
+
+    it("throws if the value is not an array", () => {
+      err(() => {
+        expect(5 as unknown as unknown[]).to.containExactly([1]);
+      }, `Expected '5' (number) to contain exactly '[1]', but it wasn't an array`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.containExactly(["Tesla"]);
+          });
+        },
+        `Expected parent.cars to contain exactly '["Tesla"]', but it had extra elements`,
+        `parent.cars: '["Tesla","Civic"]'`,
+        `Extra elements: '["Civic"]'`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/contain-exactly/index.ts
+++ b/src/expect/extensions/contain-exactly/index.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { deepEqual } from "@rbxts/deep-equal";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} contain exactly ${place.expected.value}`
+)
+  .trailingFailurePrefix(`, but it ${place.reason}`)
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+const containExactly: CustomMethodImpl<unknown[]> = (
+  _,
+  actual,
+  expectedValue: defined[]
+) => {
+  const message = baseMessage.use().expectedValue(expectedValue);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (typeOf(actual) !== "table") {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't an array");
+  }
+
+  const result = deepEqual(actual, expectedValue, { checkRightMissing: true });
+
+  if (result) {
+    const hasMissing = !result.leftMissing.isEmpty();
+    const hasExtra = !result.rightMissing.isEmpty();
+
+    if (hasMissing && hasExtra) {
+      return message
+        .metadata({ ["Extra elements"]: message.encode(result.rightMissing) })
+        .metadata({ ["Missing elements"]: message.encode(result.leftMissing) })
+        .failWithReason("was elements missing and it had extra elements");
+    } else if (hasMissing) {
+      return message
+        .metadata({ ["Missing elements"]: message.encode(result.leftMissing) })
+        .failWithReason("was missing elements");
+    } else {
+      return message
+        .metadata({ ["Extra elements"]: message.encode(result.rightMissing) })
+        .failWithReason("had extra elements");
+    }
+  }
+
+  return message.pass();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the array contains all of the values in `expectedValues`,
+     * and nothing more or less.
+     *
+     * @remarks
+     * Order doesn't matter, so long as the actual array has the same values
+     * as the expected array.
+     *
+     * There shouldn't be any extra elements in the actual array either;
+     * both arrays should **deeply** contain the same elements, with no regard to the ordering of elements.
+     *
+     * @param expectedValues - An array of elements that the actual array should be.
+     *
+     * @example
+     * ```ts
+     * expect([1,2,3]).to.containExactly([2,1,3]);
+     * expect([1,2]).to.not.containExactly([1,2,3]);
+     * expect([1,2,3]).to.not.containExactly([1,2]);
+     * ```
+     *
+     * @public
+     */
+    containExactly(expectedValues: InferArrayElement<T>[]): this;
+
+    /**
+     * Asserts that the array contains all of the values in `expectedValues`,
+     * and nothing more or less.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.containExactly | containExactly}._
+     *
+     * @public
+     */
+    containsExactly(expectedValues: InferArrayElement<T>[]): this;
+  }
+}
+
+extendMethods({
+  containExactly: containExactly,
+  containsExactly: containExactly,
+});

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -17,6 +17,8 @@
 
 import "./any-of";
 import "./array";
+import "./contain-exactly";
+import "./contain-exactly-in-order";
 import "./deep-equal";
 import "./empty";
 import "./enum";

--- a/src/message/expect-message-builder.ts
+++ b/src/message/expect-message-builder.ts
@@ -1627,6 +1627,8 @@ export class ExpectMessageBuilder {
     collapsable: boolean = false,
     collapseLength: number = getDefaultExpectConfig().collapseLength
   ) {
+    if (value === undefined) return place.undefined;
+
     const result = this.tryToEncode(value);
     encodingCache.set(value as object, result);
 

--- a/wiki/docs/api/expect.assertion.containexactly.md
+++ b/wiki/docs/api/expect.assertion.containexactly.md
@@ -1,0 +1,71 @@
+---
+id: expect.assertion.containexactly
+title: Assertion.containExactly() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [containExactly](./expect.assertion.containexactly.md)
+
+## Assertion.containExactly() method
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, and nothing more or less.
+
+**Signature:**
+
+```typescript
+containExactly(expectedValues: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+expectedValues
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+An array of elements that the actual array should be.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Remarks
+
+Order doesn't matter, so long as the actual array has the same values as the expected array.
+
+There shouldn't be any extra elements in the actual array either; both arrays should **deeply** contain the same elements, with no regard to the ordering of elements.
+
+## Example
+
+
+```ts
+expect([1,2,3]).to.containExactly([2,1,3]);
+expect([1,2]).to.not.containExactly([1,2,3]);
+expect([1,2,3]).to.not.containExactly([1,2]);
+```

--- a/wiki/docs/api/expect.assertion.containexactlyinorder.md
+++ b/wiki/docs/api/expect.assertion.containexactlyinorder.md
@@ -1,0 +1,68 @@
+---
+id: expect.assertion.containexactlyinorder
+title: Assertion.containExactlyInOrder() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [containExactlyInOrder](./expect.assertion.containexactlyinorder.md)
+
+## Assertion.containExactlyInOrder() method
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, with nothing more or less, and in the same order.
+
+**Signature:**
+
+```typescript
+containExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+expectedValues
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+An array of elements that the actual array should be.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Remarks
+
+There shouldn't be any extra elements in the actual array; both arrays should **deeply** contain the same elements, and in the same order.
+
+## Example
+
+
+```ts
+expect([1,2,3]).to.containExactlyInOrder([1,2,3]);
+expect([1,2,3]).to.not.containExactlyInOrder([1,3,2]);
+```

--- a/wiki/docs/api/expect.assertion.containsexactly.md
+++ b/wiki/docs/api/expect.assertion.containsexactly.md
@@ -1,0 +1,58 @@
+---
+id: expect.assertion.containsexactly
+title: Assertion.containsExactly() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [containsExactly](./expect.assertion.containsexactly.md)
+
+## Assertion.containsExactly() method
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, and nothing more or less.
+
+**Signature:**
+
+```typescript
+containsExactly(expectedValues: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+expectedValues
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Remarks
+
+_Type alias for [containExactly](./expect.assertion.containexactly.md)<!-- -->._

--- a/wiki/docs/api/expect.assertion.containsexactlyinorder.md
+++ b/wiki/docs/api/expect.assertion.containsexactlyinorder.md
@@ -1,0 +1,58 @@
+---
+id: expect.assertion.containsexactlyinorder
+title: Assertion.containsExactlyInOrder() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [containsExactlyInOrder](./expect.assertion.containsexactlyinorder.md)
+
+## Assertion.containsExactlyInOrder() method
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, with nothing more or less, and in the same order.
+
+**Signature:**
+
+```typescript
+containsExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+expectedValues
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Remarks
+
+_Type alias for [containExactlyInOrder](./expect.assertion.containexactlyinorder.md)<!-- -->._

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -640,6 +640,50 @@ Asserts that the value is a [boolean](https://create.roblox.com/docs/luau/boolea
 </td></tr>
 <tr><td>
 
+[containExactly(expectedValues)](./expect.assertion.containexactly.md)
+
+
+</td><td>
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, and nothing more or less.
+
+
+</td></tr>
+<tr><td>
+
+[containExactlyInOrder(expectedValues)](./expect.assertion.containexactlyinorder.md)
+
+
+</td><td>
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, with nothing more or less, and in the same order.
+
+
+</td></tr>
+<tr><td>
+
+[containsExactly(expectedValues)](./expect.assertion.containsexactly.md)
+
+
+</td><td>
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, and nothing more or less.
+
+
+</td></tr>
+<tr><td>
+
+[containsExactlyInOrder(expectedValues)](./expect.assertion.containsexactlyinorder.md)
+
+
+</td><td>
+
+Asserts that the array contains all of the values in `expectedValues`<!-- -->, with nothing more or less, and in the same order.
+
+
+</td></tr>
+<tr><td>
+
 [deepEqual(expectedValue)](./expect.assertion.deepequal.md)
 
 

--- a/wiki/docs/matchers/arrays.mdx
+++ b/wiki/docs/matchers/arrays.mdx
@@ -188,16 +188,39 @@ Expected '["Byron", "Bryan"]' to have atleast one element that starts with "Day"
 
 ### Contain exactly
 
-:::info
+You can use the [containsExactly](/docs/api/expect.assertion.containexactly.md) method to check if an array **deeply**
+contains all of the elements in another array, with no regard for order and without any extra elements.
 
-[GitHub Issue #15](https://github.com/daymxn/rbxts-expect/issues/15)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect([1, 2, 3]).to.containExactly([3, 2, 1]);
+```
+
+#### Example error
+
+```logs
+Expected '[1,2]' to contain exactly '[1,2,3]', but it was missing elements
+
+Missing elements: '[3]'
+```
 
 ### Contain exactly in order
 
-:::info
+You can use the [containsExactlyInOrder](/docs/api/expect.assertion.containexactlyinorder.md) method to check if an
+array **deeply** contains all of the elements in another array, without any extra elements and in the same order.
 
-[GitHub Issue #15](https://github.com/daymxn/rbxts-expect/issues/15)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect([1, 2, 3]).to.containsExactlyInOrder([1, 2, 3]);
+```
+
+#### Example error
+
+```logs
+Expected '[1,2,3]' to contain exactly '[1,3,2]', but it had a different value for the element at '[1]'
+
+Expected [1]: '3'
+Actual [1]: '2'
+```


### PR DESCRIPTION
Adds the matchers `containExactly` and `containExactlyInOrder`.

Also fixes an issue with `encode` throwing a runtime exception with null values when trying to add it to the cache.

Fixes #15 