### PR TITLE
Add number comparator matchers

### DIFF
--- a/.changeset/good-kangaroos-clap.md
+++ b/.changeset/good-kangaroos-clap.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Add the matchers `lessThan`, `lt` and `below`

--- a/.changeset/gorgeous-dragons-eat.md
+++ b/.changeset/gorgeous-dragons-eat.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Add the matchers `lessThanOrEqualTo`, `lte` and `most`

--- a/.changeset/new-eels-rest.md
+++ b/.changeset/new-eels-rest.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Add the matchers `greaterThan`, `gt` and `above`

--- a/.changeset/small-phones-grow.md
+++ b/.changeset/small-phones-grow.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Add the NOP `at` for numbers

--- a/.changeset/thick-fishes-pump.md
+++ b/.changeset/thick-fishes-pump.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Add the matchers `greaterThanOrEqualTo`, `gte`, and `least`

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -28,6 +28,7 @@ export interface Assertion<T = unknown> {
     arrayOf<I extends keyof CheckableTypes>(typeName: I): Assertion<I[]>;
     arrayOf<I>(checker: TypeCheckCallback<I>): Assertion<I[]>;
     arrayOf<I>(tChecker: t.check<I>): Assertion<I[]>;
+    readonly at: this;
     readonly be: this;
     readonly been: this;
     boolean(): Assertion<boolean>;

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -17,6 +17,7 @@ export interface ActualPlaceholder {
 // @public
 export interface Assertion<T = unknown> {
     readonly a: this;
+    above(value: number): Assertion<number>;
     readonly also: this;
     readonly an: this;
     readonly and: this;
@@ -31,6 +32,7 @@ export interface Assertion<T = unknown> {
     readonly at: this;
     readonly be: this;
     readonly been: this;
+    below(value: number): Assertion<number>;
     boolean(): Assertion<boolean>;
     readonly but: this;
     containExactly(expectedValues: InferArrayElement<T>[]): this;
@@ -50,6 +52,10 @@ export interface Assertion<T = unknown> {
     equal<R = T>(expectedValue: R): Assertion<R>;
     equals<R = T>(expectedValue: R): Assertion<R>;
     function(): Assertion<object>;
+    greaterThan(value: number): Assertion<number>;
+    greaterThanOrEqualTo(value: number): Assertion<number>;
+    gt(value: number): Assertion<number>;
+    gte(value: number): Assertion<number>;
     readonly have: this;
     include(expectedValue: InferArrayElement<T>): this;
     includes(expectedValue: InferArrayElement<T>): this;
@@ -58,8 +64,14 @@ export interface Assertion<T = unknown> {
     instanceOf<I>(tChecker: t.check<I>): Assertion<I>;
     readonly is: this;
     is_array?: boolean;
+    least(value: number): Assertion<number>;
     length(size: number): this;
     lengthOf(size: number): this;
+    lessThan(value: number): Assertion<number>;
+    lessThanOrEqualTo(value: number): Assertion<number>;
+    lt(value: number): Assertion<number>;
+    lte(value: number): Assertion<number>;
+    most(value: number): Assertion<number>;
     // @internal (undocumented)
     _negated: boolean;
     readonly never: this;

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -28,6 +28,7 @@ import "./instance-of";
 import "./length";
 import "./negations";
 import "./noops";
+import "./numbers";
 import "./some";
 import "./substring";
 import "./throws";

--- a/src/expect/extensions/noops/index.ts
+++ b/src/expect/extensions/noops/index.ts
@@ -120,6 +120,18 @@ declare module "@rbxts/expect" {
      *
      * @example
      * ```ts
+     * expect(5).to.be.at.least(4);
+     * ```
+     *
+     * @public
+     */
+    readonly at: this;
+
+    /**
+     * NOOP property for cleaner chaining; does nothing.
+     *
+     * @example
+     * ```ts
      * expect(1).to.not.be.a.string().or.a.table();
      * ```
      *
@@ -234,6 +246,7 @@ extendNOPs([
   "is",
   "an",
   "a",
+  "at",
   "that",
   "which",
   "does",

--- a/src/expect/extensions/number-comparators/index.spec.ts
+++ b/src/expect/extensions/number-comparators/index.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("greaterThan", () => {
+    it("checks if the actual value is greater than the expected number", () => {
+      expect(5).to.be.greaterThan(4).and.gt(3).but.not.above(6);
+    });
+  });
+
+  describe("greaterThanOrEqualTo", () => {
+    it("checks if the actual value is greater than or equal to the expected number", () => {
+      expect(5).to.be.greaterThanOrEqualTo(4).and.gte(5).but.not.at.least(6);
+    });
+  });
+
+  describe("lessThan", () => {
+    it("checks if the actual value is less than the expected number", () => {
+      expect(5).to.be.lessThan(6).and.lt(7).but.not.below(4);
+    });
+  });
+
+  describe("lessThanOrEqualTo", () => {
+    it("checks if the actual value is less than or equal to the expected number", () => {
+      expect(5).to.be.lessThanOrEqualTo(5).and.lte(6).but.not.at.most(4);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the check fails", () => {
+      err(() => {
+        expect(1).to.be.greaterThan(2);
+      }, "Expected '1' to be greater than '2'");
+
+      err(() => {
+        expect(1).to.be.gte(1).and.gte(2);
+      }, "Expected '1' to be greater than or equal to '2'");
+
+      err(() => {
+        expect(2).to.be.lessThan(1);
+      }, "Expected '2' to be less than '1'");
+
+      err(() => {
+        expect(2).to.be.lte(2).and.lte(1);
+      }, "Expected '2' to be less than or equal to '1'");
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.be.greaterThan(2);
+      }, "Expected the value to be greater than '2', but it was undefined");
+
+      err(() => {
+        expect(undefined).to.be.gte(2);
+      }, "Expected the value to be greater than or equal to '2', but it was undefined");
+
+      err(() => {
+        expect(undefined).to.be.lessThan(1);
+      }, "Expected the value to be less than '1', but it was undefined");
+
+      err(() => {
+        expect(undefined).to.be.lte(1);
+      }, "Expected the value to be less than or equal to '1', but it was undefined");
+    });
+
+    it("throws when it's not a number", () => {
+      err(() => {
+        expect("5").to.be.greaterThan(2);
+      }, `Expected "5" (string) to be greater than '2', but it wasn't a number`);
+
+      err(() => {
+        expect("5").to.be.gte(2);
+      }, `Expected "5" (string) to be greater than or equal to '2', but it wasn't a number`);
+
+      err(() => {
+        expect("5").to.be.lessThan(1);
+      }, `Expected "5" (string) to be less than '1', but it wasn't a number`);
+
+      err(() => {
+        expect("5").to.be.lte(1);
+      }, `Expected "5" (string) to be less than or equal to '1', but it wasn't a number`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.greaterThan(10);
+          });
+        },
+        `Expected parent.age to be greater than '10'`,
+        `parent.age: '5'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.greaterThanOrEqualTo(10);
+          });
+        },
+        `Expected parent.age to be greater than or equal to '10'`,
+        `parent.age: '5'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.lessThan(1);
+          });
+        },
+        `Expected parent.age to be less than '1'`,
+        `parent.age: '5'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.lessThanOrEqualTo(1);
+          });
+        },
+        `Expected parent.age to be less than or equal to '1'`,
+        `parent.age: '5'`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/number-comparators/index.ts
+++ b/src/expect/extensions/number-comparators/index.ts
@@ -1,0 +1,310 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be ${place.reason} ${place.expected.value}`
+)
+  .negationSuffix(", but it was")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+function verifyComparison(
+  message: ExpectMessageBuilder,
+  actual: unknown,
+  expected: number,
+  greater: boolean,
+  equal: boolean
+) {
+  message.expectedValue(expected);
+
+  if (actual === undefined) {
+    return message
+      .name("the value")
+      .trailingFailureSuffix(", but it was undefined")
+      .fail();
+  }
+
+  if (!typeIs(actual, "number")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .trailingFailureSuffix(", but it wasn't a number")
+      .fail();
+  }
+
+  if (equal && actual === expected) {
+    return message.negationSuffix(", but they were equal").pass();
+  }
+
+  if (greater) {
+    return actual > expected ? message.pass() : message.fail();
+  } else {
+    return actual < expected ? message.pass() : message.fail();
+  }
+}
+
+const greaterThan: CustomMethodImpl = (_, actual, expected: number) => {
+  const message = baseMessage.use().reason("greater than");
+
+  return verifyComparison(message, actual, expected, true, false);
+};
+
+const greaterThanOrEqualTo: CustomMethodImpl = (
+  _,
+  actual,
+  expected: number
+) => {
+  const message = baseMessage.use().reason("greater than or equal to");
+
+  return verifyComparison(message, actual, expected, true, true);
+};
+
+const lessThan: CustomMethodImpl = (_, actual, expected: number) => {
+  const message = baseMessage.use().reason("less than");
+
+  return verifyComparison(message, actual, expected, false, false);
+};
+
+const lessThanOrEqualTo: CustomMethodImpl = (_, actual, expected: number) => {
+  const message = baseMessage.use().reason("less than or equal to");
+
+  return verifyComparison(message, actual, expected, false, true);
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the value is greater than `value`.
+     *
+     * @param value - A number that the actual value should be greater than.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.greaterThan(4);
+     * ```
+     *
+     * @public
+     */
+    greaterThan(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is greater than `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.greaterThan | greaterThan}._
+     *
+     * @param value - A number that the actual value should be greater than.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.gt(4);
+     * ```
+     *
+     * @public
+     */
+    gt(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is greater than `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.greaterThan | greaterThan}._
+     *
+     * @param value - A number that the actual value should be greater than.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.above(4);
+     * ```
+     *
+     * @public
+     */
+    above(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is greater than or equal to `value`.
+     *
+     * @param value - A number that the actual value should be greater than or equal to.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.greaterThanOrEqualTo(4);
+     * expect(2).to.be.greaterThanOrEqualTo(2);
+     * ```
+     *
+     * @public
+     */
+    greaterThanOrEqualTo(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is greater than or equal to `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.greaterThanOrEqualTo | greaterThanOrEqualTo}._
+     *
+     * @param value - A number that the actual value should be greater than or equal to.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.gte(4);
+     * expect(2).to.be.gte(2);
+     * ```
+     *
+     * @public
+     */
+    gte(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is greater than or equal to `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.greaterThanOrEqualTo | greaterThanOrEqualTo}._
+     *
+     * @param value - A number that the actual value should be greater than or equal to.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.at.least(4);
+     * expect(2).to.be.at.least(2);
+     * ```
+     *
+     * @public
+     */
+    least(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is less than `value`.
+     *
+     * @param value - A number that the actual value should be less than.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.lessThan(4);
+     * ```
+     *
+     * @public
+     */
+    lessThan(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is less than `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.lessThan | lessThan}._
+     *
+     * @param value - A number that the actual value should be less than.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.lt(4);
+     * ```
+     *
+     * @public
+     */
+    lt(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is less than `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.lessThan | lessThan}._
+     *
+     * @param value - A number that the actual value should be less than.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.below(4);
+     * ```
+     *
+     * @public
+     */
+    below(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is less than or equal to `value`.
+     *
+     * @param value - A number that the actual value should be less than or equal to.
+     *
+     * @example
+     * ```ts
+     * expect(4).to.be.lessThanOrEqualTo(5);
+     * expect(2).to.be.lessThanOrEqualTo(2);
+     * ```
+     *
+     * @public
+     */
+    lessThanOrEqualTo(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is less than or equal to `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.lessThanOrEqualTo | lessThanOrEqualTo}._
+     *
+     * @param value - A number that the actual value should be less than or equal to.
+     *
+     * @example
+     * ```ts
+     * expect(4).to.be.lte(5);
+     * expect(2).to.be.lte(2);
+     * ```
+     *
+     * @public
+     */
+    lte(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the value is less than or equal to `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.lessThanOrEqualTo | lessThanOrEqualTo}._
+     *
+     * @param value - A number that the actual value should be less than or equal to.
+     *
+     * @example
+     * ```ts
+     * expect(4).to.be.at.most(5);
+     * expect(2).to.be.at.most(2);
+     * ```
+     *
+     * @public
+     */
+    most(value: number): Assertion<number>;
+  }
+}
+
+extendMethods({
+  greaterThan: greaterThan,
+  gt: greaterThan,
+  above: greaterThan,
+
+  greaterThanOrEqualTo: greaterThanOrEqualTo,
+  gte: greaterThanOrEqualTo,
+  least: greaterThanOrEqualTo,
+
+  lessThan: lessThan,
+  lt: lessThan,
+  below: lessThan,
+
+  lessThanOrEqualTo: lessThanOrEqualTo,
+  lte: lessThanOrEqualTo,
+  most: lessThanOrEqualTo,
+});

--- a/wiki/docs/api/expect.assertion.above.md
+++ b/wiki/docs/api/expect.assertion.above.md
@@ -1,0 +1,67 @@
+---
+id: expect.assertion.above
+title: Assertion.above() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [above](./expect.assertion.above.md)
+
+## Assertion.above() method
+
+Asserts that the value is greater than `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+above(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be greater than.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [greaterThan](./expect.assertion.greaterthan.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(5).to.be.above(4);
+```

--- a/wiki/docs/api/expect.assertion.at.md
+++ b/wiki/docs/api/expect.assertion.at.md
@@ -1,0 +1,24 @@
+---
+id: expect.assertion.at
+title: Assertion.at property
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [at](./expect.assertion.at.md)
+
+## Assertion.at property
+
+NOOP property for cleaner chaining; does nothing.
+
+**Signature:**
+
+```typescript
+readonly at: this;
+```
+
+## Example
+
+
+```ts
+expect(5).to.be.at.least(4);
+```

--- a/wiki/docs/api/expect.assertion.below.md
+++ b/wiki/docs/api/expect.assertion.below.md
@@ -1,0 +1,67 @@
+---
+id: expect.assertion.below
+title: Assertion.below() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [below](./expect.assertion.below.md)
+
+## Assertion.below() method
+
+Asserts that the value is less than `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+below(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be less than.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [lessThan](./expect.assertion.lessthan.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(5).to.be.below(4);
+```

--- a/wiki/docs/api/expect.assertion.greaterthan.md
+++ b/wiki/docs/api/expect.assertion.greaterthan.md
@@ -1,0 +1,63 @@
+---
+id: expect.assertion.greaterthan
+title: Assertion.greaterThan() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [greaterThan](./expect.assertion.greaterthan.md)
+
+## Assertion.greaterThan() method
+
+Asserts that the value is greater than `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+greaterThan(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be greater than.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Example
+
+
+```ts
+expect(5).to.be.greaterThan(4);
+```

--- a/wiki/docs/api/expect.assertion.greaterthanorequalto.md
+++ b/wiki/docs/api/expect.assertion.greaterthanorequalto.md
@@ -1,0 +1,64 @@
+---
+id: expect.assertion.greaterthanorequalto
+title: Assertion.greaterThanOrEqualTo() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [greaterThanOrEqualTo](./expect.assertion.greaterthanorequalto.md)
+
+## Assertion.greaterThanOrEqualTo() method
+
+Asserts that the value is greater than or equal to `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+greaterThanOrEqualTo(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be greater than or equal to.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Example
+
+
+```ts
+expect(5).to.be.greaterThanOrEqualTo(4);
+expect(2).to.be.greaterThanOrEqualTo(2);
+```

--- a/wiki/docs/api/expect.assertion.gt.md
+++ b/wiki/docs/api/expect.assertion.gt.md
@@ -1,0 +1,67 @@
+---
+id: expect.assertion.gt
+title: Assertion.gt() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [gt](./expect.assertion.gt.md)
+
+## Assertion.gt() method
+
+Asserts that the value is greater than `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+gt(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be greater than.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [greaterThan](./expect.assertion.greaterthan.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(5).to.be.gt(4);
+```

--- a/wiki/docs/api/expect.assertion.gte.md
+++ b/wiki/docs/api/expect.assertion.gte.md
@@ -1,0 +1,68 @@
+---
+id: expect.assertion.gte
+title: Assertion.gte() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [gte](./expect.assertion.gte.md)
+
+## Assertion.gte() method
+
+Asserts that the value is greater than or equal to `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+gte(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be greater than or equal to.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [greaterThanOrEqualTo](./expect.assertion.greaterthanorequalto.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(5).to.be.gte(4);
+expect(2).to.be.gte(2);
+```

--- a/wiki/docs/api/expect.assertion.least.md
+++ b/wiki/docs/api/expect.assertion.least.md
@@ -1,0 +1,68 @@
+---
+id: expect.assertion.least
+title: Assertion.least() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [least](./expect.assertion.least.md)
+
+## Assertion.least() method
+
+Asserts that the value is greater than or equal to `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+least(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be greater than or equal to.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [greaterThanOrEqualTo](./expect.assertion.greaterthanorequalto.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(5).to.be.at.least(4);
+expect(2).to.be.at.least(2);
+```

--- a/wiki/docs/api/expect.assertion.lessthan.md
+++ b/wiki/docs/api/expect.assertion.lessthan.md
@@ -1,0 +1,63 @@
+---
+id: expect.assertion.lessthan
+title: Assertion.lessThan() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [lessThan](./expect.assertion.lessthan.md)
+
+## Assertion.lessThan() method
+
+Asserts that the value is less than `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+lessThan(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be less than.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Example
+
+
+```ts
+expect(5).to.be.lessThan(4);
+```

--- a/wiki/docs/api/expect.assertion.lessthanorequalto.md
+++ b/wiki/docs/api/expect.assertion.lessthanorequalto.md
@@ -1,0 +1,64 @@
+---
+id: expect.assertion.lessthanorequalto
+title: Assertion.lessThanOrEqualTo() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [lessThanOrEqualTo](./expect.assertion.lessthanorequalto.md)
+
+## Assertion.lessThanOrEqualTo() method
+
+Asserts that the value is less than or equal to `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+lessThanOrEqualTo(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be less than or equal to.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Example
+
+
+```ts
+expect(4).to.be.lessThanOrEqualTo(5);
+expect(2).to.be.lessThanOrEqualTo(2);
+```

--- a/wiki/docs/api/expect.assertion.lt.md
+++ b/wiki/docs/api/expect.assertion.lt.md
@@ -1,0 +1,67 @@
+---
+id: expect.assertion.lt
+title: Assertion.lt() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [lt](./expect.assertion.lt.md)
+
+## Assertion.lt() method
+
+Asserts that the value is less than `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+lt(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be less than.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [lessThan](./expect.assertion.lessthan.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(5).to.be.lt(4);
+```

--- a/wiki/docs/api/expect.assertion.lte.md
+++ b/wiki/docs/api/expect.assertion.lte.md
@@ -1,0 +1,68 @@
+---
+id: expect.assertion.lte
+title: Assertion.lte() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [lte](./expect.assertion.lte.md)
+
+## Assertion.lte() method
+
+Asserts that the value is less than or equal to `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+lte(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be less than or equal to.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [lessThanOrEqualTo](./expect.assertion.lessthanorequalto.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(4).to.be.lte(5);
+expect(2).to.be.lte(2);
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -152,6 +152,27 @@ NOOP property for cleaner chaining; does nothing.
 </td></tr>
 <tr><td>
 
+[at](./expect.assertion.at.md)
+
+
+</td><td>
+
+`readonly`
+
+
+</td><td>
+
+this
+
+
+</td><td>
+
+NOOP property for cleaner chaining; does nothing.
+
+
+</td></tr>
+<tr><td>
+
 [be](./expect.assertion.be.md)
 
 

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -562,6 +562,17 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+[above(value)](./expect.assertion.above.md)
+
+
+</td><td>
+
+Asserts that the value is greater than `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [anyOf(values)](./expect.assertion.anyof.md)
 
 
@@ -645,6 +656,17 @@ Asserts that the value is an array of type `I`<!-- -->, according to a custom ca
 </td><td>
 
 Asserts that the value is an array of type `I`<!-- -->, according to a provided [t check](https://github.com/osyrisrblx/t)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[below(value)](./expect.assertion.below.md)
+
+
+</td><td>
+
+Asserts that the value is less than `value`<!-- -->.
 
 
 </td></tr>
@@ -826,6 +848,50 @@ Asserts that the value is a [function](https://create.roblox.com/docs/luau/funct
 </td></tr>
 <tr><td>
 
+[greaterThan(value)](./expect.assertion.greaterthan.md)
+
+
+</td><td>
+
+Asserts that the value is greater than `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[greaterThanOrEqualTo(value)](./expect.assertion.greaterthanorequalto.md)
+
+
+</td><td>
+
+Asserts that the value is greater than or equal to `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[gt(value)](./expect.assertion.gt.md)
+
+
+</td><td>
+
+Asserts that the value is greater than `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[gte(value)](./expect.assertion.gte.md)
+
+
+</td><td>
+
+Asserts that the value is greater than or equal to `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [include(expectedValue)](./expect.assertion.include.md)
 
 
@@ -881,6 +947,17 @@ Asserts that the value is an instance of `I`<!-- -->, according to a provided [t
 </td></tr>
 <tr><td>
 
+[least(value)](./expect.assertion.least.md)
+
+
+</td><td>
+
+Asserts that the value is greater than or equal to `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [length(size)](./expect.assertion.length.md)
 
 
@@ -898,6 +975,61 @@ Asserts that the value has a length of `size`<!-- -->.
 </td><td>
 
 Asserts that the value has a length of `size`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[lessThan(value)](./expect.assertion.lessthan.md)
+
+
+</td><td>
+
+Asserts that the value is less than `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[lessThanOrEqualTo(value)](./expect.assertion.lessthanorequalto.md)
+
+
+</td><td>
+
+Asserts that the value is less than or equal to `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[lt(value)](./expect.assertion.lt.md)
+
+
+</td><td>
+
+Asserts that the value is less than `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[lte(value)](./expect.assertion.lte.md)
+
+
+</td><td>
+
+Asserts that the value is less than or equal to `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[most(value)](./expect.assertion.most.md)
+
+
+</td><td>
+
+Asserts that the value is less than or equal to `value`<!-- -->.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.most.md
+++ b/wiki/docs/api/expect.assertion.most.md
@@ -1,0 +1,68 @@
+---
+id: expect.assertion.most
+title: Assertion.most() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [most](./expect.assertion.most.md)
+
+## Assertion.most() method
+
+Asserts that the value is less than or equal to `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+most(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A number that the actual value should be less than or equal to.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [lessThanOrEqualTo](./expect.assertion.lessthanorequalto.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(4).to.be.at.most(5);
+expect(2).to.be.at.most(2);
+```

--- a/wiki/docs/matchers/numbers.mdx
+++ b/wiki/docs/matchers/numbers.mdx
@@ -4,8 +4,135 @@ description: Matchers available for testing numbers.
 
 # Numbers
 
+## API
+
+### Greater than
+
+You can use the [greaterThan](/docs/api/expect.assertion.greaterthan.md) method to check if a number is greater than
+another.
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(10).to.be.greaterThan(5);
+expect(10).to.be.gt(5);
+expect(10).to.be.above(5);
+```
+
+#### Example error
+
+```logs
+Expected '1' to be greater than '2'
+```
+
+### Greater than or equal to
+
+You can use the [greaterThanOrEqualTo](/docs/api/expect.assertion.greaterthanorequalto.md) method to check if a number
+is greater than or equal to another.
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(10).to.be.greaterThanOrEqualTo(10);
+expect(10).to.be.gte(5);
+expect(10).to.be.at.least(5);
+```
+
+#### Example error
+
+```logs
+Expected '1' to be greater than or equal to '2'
+```
+
+### Less than
+
+You can use the [lessThan](/docs/api/expect.assertion.lessthan.md) method to check if a number is less than another.
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(5).to.be.lessThan(10);
+expect(5).to.be.lt(10);
+expect(5).to.be.below(10);
+```
+
+#### Example error
+
+```logs
+Expected '2' to be less than '1'
+```
+
+### Less than or equal to
+
+You can use the [lessThanOrEqualTo](/docs/api/expect.assertion.lessthanorequalto.md) method to check if a number is less
+than or equal to another.
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(5).to.be.lessThanOrEqualTo(5);
+expect(5).to.be.lte(10);
+expect(5).to.be.at.most(10);
+```
+
+#### Example error
+
+```logs
+Expected '2' to be less than or equal to '1'
+```
+
+### Negative
+
 :::info
 
-[GitHub Issue #16](https://github.com/daymxn/rbxts-expect/issues/16)
+[GitHub Issue #9](https://github.com/daymxn/rbxts-expect/issues/9)
+
+:::
+
+### Positive
+
+:::info
+
+[GitHub Issue #9](https://github.com/daymxn/rbxts-expect/issues/9)
+
+:::
+
+### Even
+
+:::info
+
+[GitHub Issue #27](https://github.com/daymxn/rbxts-expect/issues/27)
+
+:::
+
+### Odd
+
+:::info
+
+[GitHub Issue #27](https://github.com/daymxn/rbxts-expect/issues/27)
+
+:::
+
+### Between
+
+:::info
+
+[GitHub Issue #7](https://github.com/daymxn/rbxts-expect/issues/7)
+
+:::
+
+### Finite
+
+:::info
+
+[GitHub Issue #10](https://github.com/daymxn/rbxts-expect/issues/10)
+
+:::
+
+### Close to
+
+:::info
+
+[GitHub Issue #6](https://github.com/daymxn/rbxts-expect/issues/6)
 
 :::

--- a/wiki/docs/matchers/strings.mdx
+++ b/wiki/docs/matchers/strings.mdx
@@ -50,7 +50,7 @@ Expected "daymon" to be empty, but it was not
 ### Size
 
 You can use the [size](/docs/api/expect.assertion.size.md) method to check if a string has a certain amount of
-character.
+characters.
 
 ```ts
 import { expect } from "@rbxts/expect";


### PR DESCRIPTION
Adds the following number matchers:

- `greaterThan`, `gt`, `above`
- `lessThan`, `lt`, `below`
- `greaterThanOrEqualTo`, `gte`, `least`
- `lessThanOrEqualTo`, `lte`, `most`

And a NOP for `at` to use with `most` and `least`.

Fixes #16