### PR TITLE
Add `even` and `odd` matchers

### DIFF
--- a/.changeset/pink-kangaroos-breathe.md
+++ b/.changeset/pink-kangaroos-breathe.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Added support for the `even` and `odd` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -51,6 +51,7 @@ export interface Assertion<T = unknown> {
     eql<R = T>(expectedValue: R): Assertion<R>;
     equal<R = T>(expectedValue: R): Assertion<R>;
     equals<R = T>(expectedValue: R): Assertion<R>;
+    even(): Assertion<number>;
     function(): Assertion<object>;
     greaterThan(value: number): Assertion<number>;
     greaterThanOrEqualTo(value: number): Assertion<number>;
@@ -78,6 +79,7 @@ export interface Assertion<T = unknown> {
     readonly not: this;
     number(): Assertion<number>;
     object(): Assertion<object>;
+    odd(): Assertion<number>;
     readonly of: this;
     oneOf<R = T>(values: R[]): Assertion<R>;
     readonly or: this;

--- a/src/expect/extensions/even-odd/index.spec.ts
+++ b/src/expect/extensions/even-odd/index.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("even", () => {
+    it("checks if value is divisible by two without a remainder", () => {
+      for (const number of $range(1, 200)) {
+        if (number % 2 === 0) {
+          expect(number).to.be.even();
+        } else {
+          expect(number).to.not.be.even();
+        }
+      }
+    });
+  });
+
+  describe("odd", () => {
+    it("checks if value is NOT evenly divisible by two", () => {
+      for (const number of $range(1, 200)) {
+        if (number % 2 === 0) {
+          expect(number).to.not.be.odd();
+        } else {
+          expect(number).to.be.odd();
+        }
+      }
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the check fails", () => {
+      err(() => {
+        expect(1).to.be.even();
+      }, "Expected '1' to be even, but it was odd");
+
+      err(() => {
+        expect(2).to.be.odd();
+      }, "Expected '2' to be odd, but it was even");
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.be.even();
+      }, "Expected the value to be even, but it was undefined");
+
+      err(() => {
+        expect(undefined).to.be.odd();
+      }, "Expected the value to be odd, but it was undefined");
+    });
+
+    it("throws when it's not a number", () => {
+      err(() => {
+        expect("5").to.be.even();
+      }, `Expected "5" (string) to be even, but it wasn't a number`);
+
+      err(() => {
+        expect("5").to.be.odd();
+      }, `Expected "5" (string) to be odd, but it wasn't a number`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.even();
+          });
+        },
+        `Expected parent.age to be even, but it was odd`,
+        `parent.age: '5'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.age).to.be.odd();
+          });
+        },
+        `Expected age to be odd, but it was even`,
+        `age: '4'`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/even-odd/index.ts
+++ b/src/expect/extensions/even-odd/index.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be `
+)
+  .suffix(`, but it ${place.reason}`)
+  .negationSuffix(", but it was")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+function verifyEvenOdd(
+  message: ExpectMessageBuilder,
+  actual: unknown,
+  even: boolean
+) {
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "number")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a number");
+  }
+
+  if (even) {
+    return actual % 2 === 0
+      ? message.pass()
+      : message.failWithReason("was odd");
+  } else {
+    return actual % 2 === 0
+      ? message.failWithReason("was even")
+      : message.pass();
+  }
+}
+
+const even: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`even`);
+
+  return verifyEvenOdd(message, actual, true);
+};
+
+const odd: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`odd`);
+
+  return verifyEvenOdd(message, actual, false);
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the actual value is an even number.
+     *
+     * @remarks
+     * An even number is one that can be divided by 2, without any remainder.
+     *
+     * @example
+     * ```ts
+     * expect(4).to.be.even();
+     * ```
+     *
+     * @see {@link Assertion.odd | odd}
+     *
+     * @public
+     */
+    even(): Assertion<number>;
+
+    /**
+     * Asserts that the actual value is an odd number.
+     *
+     * @remarks
+     * An odd number is one that has a remainder when divided by 2.
+     *
+     * That is, it can not be evenly divided by 2.
+     *
+     * @example
+     * ```ts
+     * expect(3).to.be.odd();
+     * ```
+     *
+     * @see {@link Assertion.even | even}
+     *
+     * @public
+     */
+    odd(): Assertion<number>;
+  }
+}
+
+extendMethods({
+  even: even,
+  odd: odd,
+});

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -28,7 +28,7 @@ import "./instance-of";
 import "./length";
 import "./negations";
 import "./noops";
-import "./numbers";
+import "./number-comparators";
 import "./some";
 import "./substring";
 import "./throws";

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -23,6 +23,7 @@ import "./deep-equal";
 import "./empty";
 import "./enum";
 import "./equal";
+import "./even-odd";
 import "./include";
 import "./instance-of";
 import "./length";

--- a/wiki/docs/api/expect.assertion.even.md
+++ b/wiki/docs/api/expect.assertion.even.md
@@ -1,0 +1,31 @@
+---
+id: expect.assertion.even
+title: Assertion.even() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [even](./expect.assertion.even.md)
+
+## Assertion.even() method
+
+Asserts that the actual value is an even number.
+
+**Signature:**
+
+```typescript
+even(): Assertion<number>;
+```
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+An even number is one that can be divided by 2, without any remainder.
+
+## Example
+
+
+```ts
+expect(4).to.be.even();
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -837,6 +837,17 @@ Asserts that the value is _shallow_ equal to the `expectedValue`<!-- -->.
 </td></tr>
 <tr><td>
 
+[even()](./expect.assertion.even.md)
+
+
+</td><td>
+
+Asserts that the actual value is an even number.
+
+
+</td></tr>
+<tr><td>
+
 [function()](./expect.assertion.function.md)
 
 
@@ -1052,6 +1063,17 @@ Asserts that the value is a [number](https://create.roblox.com/docs/luau/numbers
 </td><td>
 
 Asserts that the value is a [table](https://create.roblox.com/docs/luau/tables)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[odd()](./expect.assertion.odd.md)
+
+
+</td><td>
+
+Asserts that the actual value is an odd number.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.odd.md
+++ b/wiki/docs/api/expect.assertion.odd.md
@@ -1,0 +1,33 @@
+---
+id: expect.assertion.odd
+title: Assertion.odd() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [odd](./expect.assertion.odd.md)
+
+## Assertion.odd() method
+
+Asserts that the actual value is an odd number.
+
+**Signature:**
+
+```typescript
+odd(): Assertion<number>;
+```
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+An odd number is one that has a remainder when divided by 2.
+
+That is, it can not be evenly divided by 2.
+
+## Example
+
+
+```ts
+expect(3).to.be.odd();
+```

--- a/wiki/docs/matchers/numbers.mdx
+++ b/wiki/docs/matchers/numbers.mdx
@@ -99,19 +99,39 @@ Expected '2' to be less than or equal to '1'
 
 ### Even
 
-:::info
+You can use the [even](/docs/api/expect.assertion.even.md) method to check if a number is even.
 
-[GitHub Issue #27](https://github.com/daymxn/rbxts-expect/issues/27)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect(2).to.be.even();
+expect(4).to.be.even();
+expect(-20).to.be.even();
+```
+
+#### Example error
+
+```logs
+Expected '3' to be even, but it was odd.
+```
 
 ### Odd
 
-:::info
+You can use the [odd](/docs/api/expect.assertion.odd.md) method to check if a number is odd.
 
-[GitHub Issue #27](https://github.com/daymxn/rbxts-expect/issues/27)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect(1).to.be.odd();
+expect(3).to.be.odd();
+expect(-11).to.be.odd();
+```
+
+#### Example error
+
+```logs
+Expected '2' to be odd, but it was even.
+```
 
 ### Between
 


### PR DESCRIPTION
Implements matchers for `even` and `odd` to check if a number is even or odd.

Also fixes an issue with the renamed numbers file export not being updated.

Fixes #27 