### PR TITLE
Add `between` and `within` matchers

### DIFF
--- a/.changeset/dry-onions-yawn.md
+++ b/.changeset/dry-onions-yawn.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Added support for the `between` and `within` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -33,6 +33,7 @@ export interface Assertion<T = unknown> {
     readonly be: this;
     readonly been: this;
     below(value: number): Assertion<number>;
+    between(minValue: number, maxValue: number): Assertion<number>;
     boolean(): Assertion<boolean>;
     readonly but: this;
     containExactly(expectedValues: InferArrayElement<T>[]): this;
@@ -109,6 +110,7 @@ export interface Assertion<T = unknown> {
     typeOf<I>(tChecker: t.check<I>): Assertion<I>;
     readonly value: T;
     readonly which: this;
+    within(minValue: number, maxValue: number): Assertion<number>;
 }
 
 // @public

--- a/src/expect/extensions/between/index.spec.ts
+++ b/src/expect/extensions/between/index.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("between", () => {
+    it("checks if the value is above a range", () => {
+      expect(5).to.not.be.between(1, 2).or.within(2, 3);
+    });
+
+    it("checks if the value is below a range", () => {
+      expect(5).to.not.be.between(6, 7).or.within(7, 10);
+    });
+
+    it("checks if the value is within a range", () => {
+      expect(5).to.be.between(4, 6).and.within(1, 10);
+    });
+
+    it("inclusively checks if the value is within a range", () => {
+      expect(5).to.be.between(5, 6);
+      expect(5).to.be.between(5, 5);
+    });
+
+    it("works with negative numbers", () => {
+      expect(-5).to.be.between(-10, -4);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the value is too big", () => {
+      err(() => {
+        expect(5).to.be.between(1, 2);
+      }, "Expected '5' to be a number between 1 and 2, but it was too high");
+    });
+
+    it("throws when the value is too small", () => {
+      err(() => {
+        expect(0).to.be.between(1, 2);
+      }, "Expected '0' to be a number between 1 and 2, but it was too low");
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.be.between(1, 2);
+      }, "Expected the value to be a number between 1 and 2, but it was undefined");
+    });
+
+    it("throws when it's not a number", () => {
+      err(() => {
+        expect("5").to.be.between(1, 2);
+      }, `Expected "5" (string) to be a number between 1 and 2, but it wasn't a number`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.between(25, 30);
+          });
+        },
+        `Expected parent.age to be a number between 25 and 30, but it was too low`,
+        `parent.age: '5'`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/between/index.ts
+++ b/src/expect/extensions/between/index.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be a number between `
+)
+  .negationSuffix(", but it was")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+const between: CustomMethodImpl = (
+  _,
+  actual,
+  minValue: number,
+  maxValue: number
+) => {
+  const message = baseMessage
+    .use(`${minValue} and ${maxValue}`)
+    .trailingFailureSuffix(`, but it ${place.reason}`);
+
+  if (maxValue < minValue)
+    warn(
+      `"between" called with a 'maxValue' that is less than the 'minValue'.`,
+      "This is undefined behavior, and may behave unexpectedly.",
+      `\nminValue: ${minValue}`,
+      `\nmaxValue: ${maxValue}`
+    );
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "number")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a number");
+  }
+
+  if (actual > maxValue) return message.failWithReason("was too high");
+  if (actual < minValue) return message.failWithReason("was too low");
+
+  return message.pass();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the actual value is a number within a specified range.
+     *
+     * @remarks
+     * The check is performed **inclusively**, so an actual value of `2` and
+     * a `minValue` of `2` is considered a pass.
+     *
+     * @param minValue - The lower end of what this value can be.
+     * @param maxValue - The higher end of what this value can be.
+     *
+     * @example
+     * ```ts
+     * expect(10).to.be.between(5, 15);
+     * expect(5).to.be.between(5, 6);
+     * ```
+     *
+     * @see {@link Assertion.within | within}
+     *
+     * @public
+     */
+    between(minValue: number, maxValue: number): Assertion<number>;
+
+    /**
+     * Asserts that the actual value is a number within a specified range.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.between | between}._
+     *
+     * @param minValue - The lower end of what this value can be.
+     * @param maxValue - The higher end of what this value can be.
+     *
+     * @example
+     * ```ts
+     * expect(10).to.be.within(5, 15);
+     * expect(5).to.be.within(5, 6);
+     * ```
+     *
+     * @public
+     */
+    within(minValue: number, maxValue: number): Assertion<number>;
+  }
+}
+
+extendMethods({
+  between: between,
+  within: between,
+});

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -17,6 +17,7 @@
 
 import "./any-of";
 import "./array";
+import "./between";
 import "./contain-exactly";
 import "./contain-exactly-in-order";
 import "./deep-equal";

--- a/wiki/docs/api/expect.assertion.between.md
+++ b/wiki/docs/api/expect.assertion.between.md
@@ -1,0 +1,84 @@
+---
+id: expect.assertion.between
+title: Assertion.between() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [between](./expect.assertion.between.md)
+
+## Assertion.between() method
+
+Asserts that the actual value is a number within a specified range.
+
+**Signature:**
+
+```typescript
+between(minValue: number, maxValue: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+minValue
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The lower end of what this value can be.
+
+
+</td></tr>
+<tr><td>
+
+maxValue
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The higher end of what this value can be.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+The check is performed **inclusively**, so an actual value of `2` and a `minValue` of `2` is considered a pass.
+
+## Example
+
+
+```ts
+expect(10).to.be.between(5, 15);
+expect(5).to.be.between(5, 6);
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -672,6 +672,17 @@ Asserts that the value is less than `value`<!-- -->.
 </td></tr>
 <tr><td>
 
+[between(minValue, maxValue)](./expect.assertion.between.md)
+
+
+</td><td>
+
+Asserts that the actual value is a number within a specified range.
+
+
+</td></tr>
+<tr><td>
+
 [boolean()](./expect.assertion.boolean.md)
 
 
@@ -1261,6 +1272,17 @@ Asserts that the value is of type `I`<!-- -->, according to a custom callback [T
 </td><td>
 
 Asserts that the value is of type `I`<!-- -->, according to a provided [t check](https://github.com/osyrisrblx/t)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[within(minValue, maxValue)](./expect.assertion.within.md)
+
+
+</td><td>
+
+Asserts that the actual value is a number within a specified range.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.within.md
+++ b/wiki/docs/api/expect.assertion.within.md
@@ -1,0 +1,84 @@
+---
+id: expect.assertion.within
+title: Assertion.within() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [within](./expect.assertion.within.md)
+
+## Assertion.within() method
+
+Asserts that the actual value is a number within a specified range.
+
+**Signature:**
+
+```typescript
+within(minValue: number, maxValue: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+minValue
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The lower end of what this value can be.
+
+
+</td></tr>
+<tr><td>
+
+maxValue
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The higher end of what this value can be.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for [between](./expect.assertion.between.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(10).to.be.within(5, 15);
+expect(5).to.be.within(5, 6);
+```

--- a/wiki/docs/matchers/numbers.mdx
+++ b/wiki/docs/matchers/numbers.mdx
@@ -135,11 +135,22 @@ Expected '2' to be odd, but it was even.
 
 ### Between
 
-:::info
+You can use the [between](/docs/api/expect.assertion.between.md) or [within](/docs/api/expect.assertion.within.md)
+methods to check if a number is within a specified range (inclusively).
 
-[GitHub Issue #7](https://github.com/daymxn/rbxts-expect/issues/7)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect(5).to.be.within(1, 10);
+expect(0).to.be.between(0, 100);
+expect(-10).to.be.within(-20, 20);
+```
+
+#### Example error
+
+```logs
+Expected '10' to be a number between 5 and 8, but it was too high.
+```
 
 ### Finite
 


### PR DESCRIPTION
Implements matchers for the `between` (or `within`) matcher to check if a number is within a range.

Fixes #7 