### PR TITLE
Add `defined` and `undefined` matchers

### DIFF
--- a/.changeset/happy-lamps-own.md
+++ b/.changeset/happy-lamps-own.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Add support for the `defined`, `ok`, `exist`, `exists`, `undefined`, `null` and `nil` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -42,6 +42,7 @@ export interface Assertion<T = unknown> {
     containsExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
     deepEqual<R = T>(expectedValue: R): Assertion<R>;
     deepEquals<R = T>(expectedValue: R): Assertion<R>;
+    defined(): this;
     readonly does: this;
     empty(): Assertion<T>;
     enum<R>(enumType: R & Record<number, string>): Assertion<EnumValue<R>>;
@@ -53,6 +54,8 @@ export interface Assertion<T = unknown> {
     equal<R = T>(expectedValue: R): Assertion<R>;
     equals<R = T>(expectedValue: R): Assertion<R>;
     even(): Assertion<number>;
+    exist(): this;
+    exists(): this;
     function(): Assertion<object>;
     greaterThan(value: number): Assertion<number>;
     greaterThanOrEqualTo(value: number): Assertion<number>;
@@ -77,11 +80,14 @@ export interface Assertion<T = unknown> {
     // @internal (undocumented)
     _negated: boolean;
     readonly never: this;
+    nil(): this;
     readonly not: this;
+    null(): this;
     number(): Assertion<number>;
     object(): Assertion<object>;
     odd(): Assertion<number>;
     readonly of: this;
+    ok(): this;
     oneOf<R = T>(values: R[]): Assertion<R>;
     readonly or: this;
     // @internal (undocumented)
@@ -108,6 +114,7 @@ export interface Assertion<T = unknown> {
     typeOf<I extends keyof CheckableTypes>(name: I): Assertion<I>;
     typeOf<I>(checker: TypeCheckCallback<T>): Assertion<I>;
     typeOf<I>(tChecker: t.check<I>): Assertion<I>;
+    undefined(): this;
     readonly value: T;
     readonly which: this;
     within(minValue: number, maxValue: number): Assertion<number>;

--- a/src/expect/expect.ts
+++ b/src/expect/expect.ts
@@ -20,7 +20,7 @@ import Object from "@rbxts/object-utils";
 import { reverseArray } from "@rbxts/reverse-array";
 import { includes } from "@rbxts/string-utils";
 import { mapObjectValues } from "@src/util/object";
-import { computeFullProxyPath, isProxy } from "@src/util/proxy";
+import { computeFullProxyPath, getProxyValue, isProxy } from "@src/util/proxy";
 import { getNegationExtensions, getNOPExtensions } from "./extend";
 import { CustomMethodImpl, getMethodExtensions } from "./extend/methods";
 
@@ -175,7 +175,7 @@ export function expect<T>(value: T): Assertion<T> {
   };
 
   if (isProxy(value)) {
-    newAssert.value = value._proxy_value;
+    newAssert.value = getProxyValue(value);
     newAssert._proxy = value;
   } else {
     newAssert.value = value;

--- a/src/expect/extensions/defined/index.spec.ts
+++ b/src/expect/extensions/defined/index.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("defined", () => {
+    it("checks if value is not null", () => {
+      expect("daymon")
+        .to.be.ok()
+        .and.to.be.defined()
+        .and.to.exist()
+        .and.also.exists();
+
+      expect(undefined).to.not.be.ok();
+    });
+  });
+
+  describe("undefined", () => {
+    it("checks if value is null", () => {
+      expect(undefined).to.be.undefined().and.to.be.null().and.to.nil();
+
+      expect("Daymon").to.not.be.undefined();
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the check fails", () => {
+      err(() => {
+        expect("Daymon").to.be.undefined();
+      }, `Expected "Daymon" (string) to be undefined, but it was defined`);
+
+      err(() => {
+        expect(undefined).to.be.ok();
+      }, `Expected the value to be defined, but it was undefined`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.undefined();
+          });
+        },
+        `Expected parent.age to be undefined, but it was defined`,
+        `parent.age: '5'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.data).to.be.defined();
+          });
+        },
+        `Expected data to be defined, but it was undefined`,
+        `Actual: '{"parent":{"data":{"id":1},"cars":["Tesla","Civic"],"name":"Daymon","age":5},"cars":[],"name":"Kyle","age":4}'`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/defined/index.ts
+++ b/src/expect/extensions/defined/index.ts
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+import {
+  computeFullProxyPath,
+  getNearestDefinedProxy,
+  getProxyValue,
+} from "@src/util/proxy";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be `
+)
+  .name(`${place.actual.value} (${place.actual.type})`)
+  .suffix(`, but it ${place.reason}`)
+  .negationSuffix(", but it was");
+
+const beDefined: CustomMethodImpl = (source, actual) => {
+  const message = baseMessage.use(`defined`);
+
+  if (actual === undefined) {
+    if (source._proxy) {
+      const nearestDefinedProxy = getNearestDefinedProxy(source._proxy);
+      if (nearestDefinedProxy) {
+        message.nestedMetadata({
+          [computeFullProxyPath(nearestDefinedProxy) ?? "Actual"]:
+            message.encode(getProxyValue(nearestDefinedProxy)),
+        });
+      } else {
+        message.nestedMetadata({
+          Actual: place.nil,
+        });
+      }
+    }
+    return message.name("the value").failWithReason("was undefined.");
+  }
+
+  return message
+    .nestedMetadata({
+      [place.path]: place.actual.value,
+    })
+    .pass();
+};
+
+const beUndefined: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`undefined`);
+
+  if (actual === undefined) {
+    return message.name("the value").pass();
+  }
+
+  return message
+    .nestedMetadata({
+      [place.path]: place.actual.value,
+    })
+    .failWithReason("was defined");
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the actual value is a non `null` value.
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.be.defined();
+     * ```
+     *
+     * @see {@link Assertion.undefined | undefined}
+     *
+     * @public
+     */
+    defined(): this;
+
+    /**
+     * Asserts that the actual value is a non `null` value.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.defined | defined}._
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.be.ok();
+     * ```
+     *
+     * @public
+     */
+    ok(): this;
+
+    /**
+     * Asserts that the actual value is a non `null` value.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.defined | defined}._
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.exist();
+     * ```
+     *
+     * @public
+     */
+    exist(): this;
+
+    /**
+     * Asserts that the actual value is a non `null` value.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.defined | defined}._
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.be.a.thing.that.exists();
+     * ```
+     *
+     * @public
+     */
+    exists(): this;
+
+    /**
+     * Asserts that the actual value is a `null` value.
+     *
+     * @example
+     * ```ts
+     * expect(undefined).to.be.undefined();
+     * ```
+     *
+     * @see {@link Assertion.defined | defined}
+     *
+     * @public
+     */
+    undefined(): this;
+
+    /**
+     * Asserts that the actual value is a `null` value.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.undefined | undefined}._
+     *
+     * @example
+     * ```ts
+     * expect(undefined).to.be.null();
+     * ```
+     *
+     * @see {@link Assertion.defined | defined}
+     *
+     * @public
+     */
+    null(): this;
+
+    /**
+     * Asserts that the actual value is a `null` value.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.undefined | undefined}._
+     *
+     * @example
+     * ```ts
+     * expect(undefined).to.be.nil();
+     * ```
+     *
+     * @see {@link Assertion.defined | defined}
+     *
+     * @public
+     */
+    nil(): this;
+  }
+}
+
+extendMethods({
+  defined: beDefined,
+  ok: beDefined,
+  exist: beDefined,
+  exists: beDefined,
+  undefined: beUndefined,
+  null: beUndefined,
+  nil: beUndefined,
+});

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -21,6 +21,7 @@ import "./between";
 import "./contain-exactly";
 import "./contain-exactly-in-order";
 import "./deep-equal";
+import "./defined";
 import "./empty";
 import "./enum";
 import "./equal";

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -263,12 +263,29 @@ function OnIndex<T>(Self: Proxy<T>, index: unknown) {
     throw `You can't acces '${index}' directly. Instead, either use 'rawget', or call one of the helper methods like 'getProxyValue'.`;
   }
 
-  return createProxy(rawget(Self._proxy_value, index), Self, tostring(index));
+  return createProxy(rawget(getProxyValue(Self), index), Self, tostring(index));
+}
+
+/**
+ * TODO()
+ * @param proxy
+ * @returns
+ */
+export function getNearestDefinedProxy<T = unknown, R = unknown>(
+  proxy: Proxy<T>
+): Proxy<R> | undefined {
+  let current: Proxy<T> | undefined = proxy;
+
+  while (current && getProxyValue(current) === undefined) {
+    current = getProxyParent(current);
+  }
+
+  return current as never;
 }
 
 /**
  * Safely gets the {@link ProxyInstance._proxy_value | value} of a proxy,
- * without trigger any metamethods.
+ * without triggering any metamethods.
  *
  * @param proxy - The proxy to get the value of.
  *
@@ -280,9 +297,11 @@ export function getProxyValue<T = unknown>(proxy: Proxy<T>) {
   return rawget(proxy, "_proxy_value") as T;
 }
 
+export function getProxyValueOrValue<T = unknown>(maybeProxy: T) {}
+
 /**
  * Safely gets the {@link ProxyInstance._proxy_path | path} of a proxy,
- * without trigger any metamethods.
+ * without triggering any metamethods.
  *
  * @param proxy - The proxy to get the path of.
  *
@@ -296,7 +315,7 @@ export function getProxyPath<T = unknown>(proxy: Proxy<T>) {
 
 /**
  * Safely gets the {@link ProxyInstance._proxy_parent | parent} of a proxy,
- * without trigger any metamethods.
+ * without triggering any metamethods.
  *
  * @param proxy - The proxy to get the parent of.
  *

--- a/wiki/docs/api/expect.assertion.defined.md
+++ b/wiki/docs/api/expect.assertion.defined.md
@@ -1,0 +1,27 @@
+---
+id: expect.assertion.defined
+title: Assertion.defined() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [defined](./expect.assertion.defined.md)
+
+## Assertion.defined() method
+
+Asserts that the actual value is a non `null` value.
+
+**Signature:**
+
+```typescript
+defined(): this;
+```
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect("Daymon").to.be.defined();
+```

--- a/wiki/docs/api/expect.assertion.exist.md
+++ b/wiki/docs/api/expect.assertion.exist.md
@@ -1,0 +1,31 @@
+---
+id: expect.assertion.exist
+title: Assertion.exist() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [exist](./expect.assertion.exist.md)
+
+## Assertion.exist() method
+
+Asserts that the actual value is a non `null` value.
+
+**Signature:**
+
+```typescript
+exist(): this;
+```
+**Returns:**
+
+this
+
+## Remarks
+
+_Type alias for [defined](./expect.assertion.defined.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect("Daymon").to.exist();
+```

--- a/wiki/docs/api/expect.assertion.exists.md
+++ b/wiki/docs/api/expect.assertion.exists.md
@@ -1,0 +1,31 @@
+---
+id: expect.assertion.exists
+title: Assertion.exists() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [exists](./expect.assertion.exists.md)
+
+## Assertion.exists() method
+
+Asserts that the actual value is a non `null` value.
+
+**Signature:**
+
+```typescript
+exists(): this;
+```
+**Returns:**
+
+this
+
+## Remarks
+
+_Type alias for [defined](./expect.assertion.defined.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect("Daymon").to.be.a.thing.that.exists();
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -760,6 +760,17 @@ Asserts that the value is _deep_ equal to the `expectedValue`<!-- -->.
 </td></tr>
 <tr><td>
 
+[defined()](./expect.assertion.defined.md)
+
+
+</td><td>
+
+Asserts that the actual value is a non `null` value.
+
+
+</td></tr>
+<tr><td>
+
 [empty()](./expect.assertion.empty.md)
 
 
@@ -854,6 +865,28 @@ Asserts that the value is _shallow_ equal to the `expectedValue`<!-- -->.
 </td><td>
 
 Asserts that the actual value is an even number.
+
+
+</td></tr>
+<tr><td>
+
+[exist()](./expect.assertion.exist.md)
+
+
+</td><td>
+
+Asserts that the actual value is a non `null` value.
+
+
+</td></tr>
+<tr><td>
+
+[exists()](./expect.assertion.exists.md)
+
+
+</td><td>
+
+Asserts that the actual value is a non `null` value.
 
 
 </td></tr>
@@ -1057,6 +1090,28 @@ Asserts that the value is less than or equal to `value`<!-- -->.
 </td></tr>
 <tr><td>
 
+[nil()](./expect.assertion.nil.md)
+
+
+</td><td>
+
+Asserts that the actual value is a `null` value.
+
+
+</td></tr>
+<tr><td>
+
+[null()](./expect.assertion.null.md)
+
+
+</td><td>
+
+Asserts that the actual value is a `null` value.
+
+
+</td></tr>
+<tr><td>
+
 [number()](./expect.assertion.number.md)
 
 
@@ -1085,6 +1140,17 @@ Asserts that the value is a [table](https://create.roblox.com/docs/luau/tables)<
 </td><td>
 
 Asserts that the actual value is an odd number.
+
+
+</td></tr>
+<tr><td>
+
+[ok()](./expect.assertion.ok.md)
+
+
+</td><td>
+
+Asserts that the actual value is a non `null` value.
 
 
 </td></tr>
@@ -1272,6 +1338,17 @@ Asserts that the value is of type `I`<!-- -->, according to a custom callback [T
 </td><td>
 
 Asserts that the value is of type `I`<!-- -->, according to a provided [t check](https://github.com/osyrisrblx/t)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[undefined()](./expect.assertion.undefined.md)
+
+
+</td><td>
+
+Asserts that the actual value is a `null` value.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.nil.md
+++ b/wiki/docs/api/expect.assertion.nil.md
@@ -1,0 +1,31 @@
+---
+id: expect.assertion.nil
+title: Assertion.nil() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [nil](./expect.assertion.nil.md)
+
+## Assertion.nil() method
+
+Asserts that the actual value is a `null` value.
+
+**Signature:**
+
+```typescript
+nil(): this;
+```
+**Returns:**
+
+this
+
+## Remarks
+
+_Type alias for [undefined](./expect.assertion.undefined.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(undefined).to.be.nil();
+```

--- a/wiki/docs/api/expect.assertion.null.md
+++ b/wiki/docs/api/expect.assertion.null.md
@@ -1,0 +1,31 @@
+---
+id: expect.assertion.null
+title: Assertion.null() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [null](./expect.assertion.null.md)
+
+## Assertion.null() method
+
+Asserts that the actual value is a `null` value.
+
+**Signature:**
+
+```typescript
+null(): this;
+```
+**Returns:**
+
+this
+
+## Remarks
+
+_Type alias for [undefined](./expect.assertion.undefined.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(undefined).to.be.null();
+```

--- a/wiki/docs/api/expect.assertion.ok.md
+++ b/wiki/docs/api/expect.assertion.ok.md
@@ -1,0 +1,31 @@
+---
+id: expect.assertion.ok
+title: Assertion.ok() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [ok](./expect.assertion.ok.md)
+
+## Assertion.ok() method
+
+Asserts that the actual value is a non `null` value.
+
+**Signature:**
+
+```typescript
+ok(): this;
+```
+**Returns:**
+
+this
+
+## Remarks
+
+_Type alias for [defined](./expect.assertion.defined.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect("Daymon").to.be.ok();
+```

--- a/wiki/docs/api/expect.assertion.undefined.md
+++ b/wiki/docs/api/expect.assertion.undefined.md
@@ -1,0 +1,27 @@
+---
+id: expect.assertion.undefined
+title: Assertion.undefined() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [undefined](./expect.assertion.undefined.md)
+
+## Assertion.undefined() method
+
+Asserts that the actual value is a `null` value.
+
+**Signature:**
+
+```typescript
+undefined(): this;
+```
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect(undefined).to.be.undefined();
+```

--- a/wiki/docs/api/expect.getproxyparent.md
+++ b/wiki/docs/api/expect.getproxyparent.md
@@ -8,7 +8,7 @@ hide_title: true
 
 ## getProxyParent() function
 
-Safely gets the [parent](./expect.proxyinstance._proxy_parent.md) of a proxy, without trigger any metamethods.
+Safely gets the [parent](./expect.proxyinstance._proxy_parent.md) of a proxy, without triggering any metamethods.
 
 **Signature:**
 

--- a/wiki/docs/api/expect.getproxypath.md
+++ b/wiki/docs/api/expect.getproxypath.md
@@ -8,7 +8,7 @@ hide_title: true
 
 ## getProxyPath() function
 
-Safely gets the [path](./expect.proxyinstance._proxy_path.md) of a proxy, without trigger any metamethods.
+Safely gets the [path](./expect.proxyinstance._proxy_path.md) of a proxy, without triggering any metamethods.
 
 **Signature:**
 

--- a/wiki/docs/api/expect.getproxyvalue.md
+++ b/wiki/docs/api/expect.getproxyvalue.md
@@ -8,7 +8,7 @@ hide_title: true
 
 ## getProxyValue() function
 
-Safely gets the [value](./expect.proxyinstance._proxy_value.md) of a proxy, without trigger any metamethods.
+Safely gets the [value](./expect.proxyinstance._proxy_value.md) of a proxy, without triggering any metamethods.
 
 **Signature:**
 

--- a/wiki/docs/api/expect.md
+++ b/wiki/docs/api/expect.md
@@ -149,7 +149,7 @@ Gets the (current) default [ExpectConfig](./expect.expectconfig.md)<!-- -->.
 
 </td><td>
 
-Safely gets the [parent](./expect.proxyinstance._proxy_parent.md) of a proxy, without trigger any metamethods.
+Safely gets the [parent](./expect.proxyinstance._proxy_parent.md) of a proxy, without triggering any metamethods.
 
 
 </td></tr>
@@ -160,7 +160,7 @@ Safely gets the [parent](./expect.proxyinstance._proxy_parent.md) of a proxy, wi
 
 </td><td>
 
-Safely gets the [path](./expect.proxyinstance._proxy_path.md) of a proxy, without trigger any metamethods.
+Safely gets the [path](./expect.proxyinstance._proxy_path.md) of a proxy, without triggering any metamethods.
 
 
 </td></tr>
@@ -171,7 +171,7 @@ Safely gets the [path](./expect.proxyinstance._proxy_path.md) of a proxy, withou
 
 </td><td>
 
-Safely gets the [value](./expect.proxyinstance._proxy_value.md) of a proxy, without trigger any metamethods.
+Safely gets the [value](./expect.proxyinstance._proxy_value.md) of a proxy, without triggering any metamethods.
 
 
 </td></tr>

--- a/wiki/docs/matchers/basic.mdx
+++ b/wiki/docs/matchers/basic.mdx
@@ -76,3 +76,43 @@ Expected '5' to be of type 'string', but it was a 'number'
 [GitHub Issue #5](https://github.com/daymxn/rbxts-expect/issues/5)
 
 :::
+
+### Defined
+
+You can use the [defined](/docs/api/expect.assertion.defined.md) method to check if a provided value is not null.
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(1).to.be.defined();
+expect(1).to.be.ok();
+expect(1).to.exist();
+
+expect(undefined).to.not.be.defined();
+```
+
+#### Example error
+
+```logs
+Expected the value to be defined, but it was undefined
+```
+
+### Undefined
+
+You can use the [undefined](/docs/api/expect.assertion.undefined.md) method to check if a provided value is null.
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(undefined).to.be.undefined();
+expect(undefined).to.be.null();
+expect(undefined).to.be.nil();
+
+expect(5).to.not.be.undefined();
+```
+
+#### Example error
+
+```logs
+Expected '5' (number) to be undefined, but it was defined
+```


### PR DESCRIPTION
Adds support for the `defined` and `undefined` matchers that check if a value is `null`.

Also adds support for various alternative mappings for both matchers.

Fixes #8 