### PR TITLE
Add missing changelog/jsdocs

### DIFF
--- a/.changeset/dry-onions-yawn.md
+++ b/.changeset/dry-onions-yawn.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
 Added support for the `between` and `within` matchers

--- a/.changeset/good-kangaroos-clap.md
+++ b/.changeset/good-kangaroos-clap.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
-Add the matchers `lessThan`, `lt` and `below`
+Added the matchers `lessThan`, `lt` and `below`

--- a/.changeset/gorgeous-dragons-eat.md
+++ b/.changeset/gorgeous-dragons-eat.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
-Add the matchers `lessThanOrEqualTo`, `lte` and `most`
+Added the matchers `lessThanOrEqualTo`, `lte` and `most`

--- a/.changeset/happy-lamps-own.md
+++ b/.changeset/happy-lamps-own.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
-Add support for the `defined`, `ok`, `exist`, `exists`, `undefined`, `null` and `nil` matchers
+Added support for the `defined`, `ok`, `exist`, `exists`, `undefined`, `null` and `nil` matchers

--- a/.changeset/heavy-penguins-drum.md
+++ b/.changeset/heavy-penguins-drum.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
 Added support for the `containExactly` matcher

--- a/.changeset/lucky-pans-talk.md
+++ b/.changeset/lucky-pans-talk.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
 Added support for the `some` matcher

--- a/.changeset/mean-fans-pump.md
+++ b/.changeset/mean-fans-pump.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Fixed a bug that prevented proxies from indexing null values

--- a/.changeset/new-eels-rest.md
+++ b/.changeset/new-eels-rest.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
-Add the matchers `greaterThan`, `gt` and `above`
+Added the matchers `greaterThan`, `gt` and `above`

--- a/.changeset/pink-kangaroos-breathe.md
+++ b/.changeset/pink-kangaroos-breathe.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
 Added support for the `even` and `odd` matchers

--- a/.changeset/small-phones-grow.md
+++ b/.changeset/small-phones-grow.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
-Add the NOP `at` for numbers
+Added the NOP `at` for numbers

--- a/.changeset/smart-frogs-vanish.md
+++ b/.changeset/smart-frogs-vanish.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
 Added support for the `containExactlyInOrder` matcher

--- a/.changeset/thick-fishes-pump.md
+++ b/.changeset/thick-fishes-pump.md
@@ -1,5 +1,5 @@
 ---
-"@rbxts/expect": patch
+"@rbxts/expect": minor
 ---
 
-Add the matchers `greaterThanOrEqualTo`, `gte`, and `least`
+Added the matchers `greaterThanOrEqualTo`, `gte`, and `least`

--- a/.changeset/thick-shoes-repair.md
+++ b/.changeset/thick-shoes-repair.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added the `getNearestDefinedProxy` function for propagating defined values in deeply nested null chains

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -215,6 +215,9 @@ export type Filter<T = unknown> = (value: T) => boolean;
 export function getDefaultExpectConfig(): ExpectConfig;
 
 // @public
+export function getNearestDefinedProxy<T = unknown, R = unknown>(proxy: Proxy<T>): Proxy<R> | undefined;
+
+// @public
 export function getProxyParent<T = unknown, R = unknown>(proxy: Proxy<T>): Proxy<R> | undefined;
 
 // @public

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export {
   computeFullProxyPath,
   createProxy,
   err,
+  getNearestDefinedProxy,
   getProxyParent,
   getProxyPath,
   getProxyValue,

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -20,6 +20,7 @@ export {
   ProxyInstance,
   computeFullProxyPath,
   createProxy,
+  getNearestDefinedProxy,
   getProxyParent,
   getProxyPath,
   getProxyValue,

--- a/src/util/proxy.ts
+++ b/src/util/proxy.ts
@@ -267,9 +267,31 @@ function OnIndex<T>(Self: Proxy<T>, index: unknown) {
 }
 
 /**
- * TODO()
- * @param proxy
- * @returns
+ * Finds the nearest proxy in the hierarchy that has a non null
+ * value, if any.
+ *
+ * @example
+ * ```ts
+ * const person = {
+ *   name: "Daymon",
+ *   child: {
+ *     name: "Michael"
+ *   }
+ * }
+ *
+ * withProxy(person, (proxy) => {
+ *   // assume this is valid typescript
+ *   const greatGrandChild = proxy.child.child.child;
+ *   expect(getNearestDefinedProxy(greatGrandChild)).to.deepEqual(person.child);
+ * });
+ * ```
+ *
+ * @param proxy - The child to start the search from.
+ *
+ * @returns The closest {@link ProxyInstance | proxy} that has a valid (non null) {@link ProxyInstance._proxy_value | value},
+ * or undefined if all proxies have null values.
+ *
+ * @public
  */
 export function getNearestDefinedProxy<T = unknown, R = unknown>(
   proxy: Proxy<T>

--- a/wiki/docs/api/expect.getnearestdefinedproxy.md
+++ b/wiki/docs/api/expect.getnearestdefinedproxy.md
@@ -1,0 +1,76 @@
+---
+id: expect.getnearestdefinedproxy
+title: getNearestDefinedProxy() function
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [getNearestDefinedProxy](./expect.getnearestdefinedproxy.md)
+
+## getNearestDefinedProxy() function
+
+Finds the nearest proxy in the hierarchy that has a non null value, if any.
+
+**Signature:**
+
+```typescript
+declare function getNearestDefinedProxy<T = unknown, R = unknown>(proxy: Proxy<T>): Proxy<R> | undefined;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+proxy
+
+
+</td><td>
+
+[Proxy](./expect.proxy.md)<!-- -->&lt;T&gt;
+
+
+</td><td>
+
+The child to start the search from.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Proxy](./expect.proxy.md)<!-- -->&lt;R&gt; \| undefined
+
+The closest [proxy](./expect.proxyinstance.md) that has a valid (non null) [value](./expect.proxyinstance._proxy_value.md)<!-- -->, or undefined if all proxies have null values.
+
+## Example
+
+
+```ts
+const person = {
+  name: "Daymon",
+  child: {
+    name: "Michael"
+  }
+}
+
+withProxy(person, (proxy) => {
+  // assume this is valid typescript
+  const greatGrandChild = proxy.child.child.child;
+  expect(getNearestDefinedProxy(greatGrandChild)).to.deepEqual(person.child);
+});
+```

--- a/wiki/docs/api/expect.md
+++ b/wiki/docs/api/expect.md
@@ -144,6 +144,17 @@ Gets the (current) default [ExpectConfig](./expect.expectconfig.md)<!-- -->.
 </td></tr>
 <tr><td>
 
+[getNearestDefinedProxy(proxy)](./expect.getnearestdefinedproxy.md)
+
+
+</td><td>
+
+Finds the nearest proxy in the hierarchy that has a non null value, if any.
+
+
+</td></tr>
+<tr><td>
+
 [getProxyParent(proxy)](./expect.getproxyparent.md)
 
 


### PR DESCRIPTION
The previous pr (#31) contained a fix for proxies where they would throw an error when you attempted to index a null value. This PR fixes that. It also added the method `getNearestDefinedProxy`- but the jsdocs were absent, so this PR adds them.

And finally, a lot of the changesets were incorrectly added as patches- when they should've been minors since they added new API methods- so I've rectified that. 