### PR TITLE
Add the pattern matcher

### DIFF
--- a/.changeset/serious-ants-jump.md
+++ b/.changeset/serious-ants-jump.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `pattern` matcher

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -90,6 +90,7 @@ export interface Assertion<T = unknown> {
     ok(): this;
     oneOf<R = T>(values: R[]): Assertion<R>;
     readonly or: this;
+    pattern(pattern: string): this;
     // @internal (undocumented)
     _proxy?: Proxy<T>;
     // @internal (undocumented)

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -32,6 +32,7 @@ import "./length";
 import "./negations";
 import "./noops";
 import "./number-comparators";
+import "./pattern";
 import "./some";
 import "./substring";
 import "./throws";

--- a/src/expect/extensions/pattern/index.spec.ts
+++ b/src/expect/extensions/pattern/index.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("pattern", () => {
+    it("looks for a string pattern in the string", () => {
+      expect("My Name")
+        .to.have.the.pattern("^%a")
+        .but.not.have.the.pattern("^$l");
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when a match isn't found", () => {
+      err(() => {
+        expect("Hello world").to.have.the.pattern("^Goodbye");
+      }, 'Expected "Hello world" to have a match for the pattern /^Goodbye/, but it was missing');
+    });
+
+    it("outputs the matches when negated", () => {
+      err(
+        () => {
+          expect("Hello World").to.not.have.the.pattern("%u%l");
+        },
+        'Expected "Hello World" to NOT have a match for the pattern /%u%l/, but it did',
+        'Match: "He"'
+      );
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.have.the.pattern("Goodbye");
+      }, "Expected the value to have a match for the pattern /Goodbye/, but it was undefined");
+    });
+
+    it("throws when it's not a string", () => {
+      err(() => {
+        expect(5).to.have.the.pattern("Goodbye");
+      }, `Expected '5' (number) to have a match for the pattern /Goodbye/, but it wasn't a string`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.name).to.have.the.pattern("^%l");
+          });
+        },
+        "Expected parent.name to have a match for the pattern /^%l/, but it was missing",
+        'parent.name: "Daymon"'
+      );
+    });
+  });
+};

--- a/src/expect/extensions/pattern/index.ts
+++ b/src/expect/extensions/pattern/index.ts
@@ -15,57 +15,65 @@
  * limitations under the License.
  */
 
-import { includes } from "@rbxts/string-utils";
 import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
 import { ExpectMessageBuilder } from "@src/message";
 import { place } from "@src/message/placeholders";
 
 const baseMessage = new ExpectMessageBuilder(
-  `Expected ${place.name} to ${place.not} have the substring ${place.expected.value}`
-).nestedMetadata({
-  [place.path]: place.actual.value,
-});
+  `Expected ${place.name} to ${place.not} have a match for the pattern `
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .negationSuffix(", but it did")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
 
-const substring: CustomMethodImpl = (_, actual, str: string) => {
-  const message = baseMessage.use().expectedValue(str);
+const hasPattern: CustomMethodImpl = (_, actual, pattern: string) => {
+  const message = baseMessage.use(`/${pattern}/`);
 
   if (actual === undefined) {
-    return message
-      .name("the value")
-      .trailingFailureSuffix(", but it was undefined")
-      .fail();
+    return message.name("the value").failWithReason("was undefined");
   }
 
   if (!typeIs(actual, "string")) {
     return message
       .name(`${place.actual.value} (${place.actual.type})`)
-      .trailingFailureSuffix(", but it wasn't a string")
-      .fail();
+      .failWithReason("wasn't a string");
   }
 
-  return includes(actual, str) ? message.pass() : message.fail();
+  const match = actual.match(pattern);
+
+  if (match.isEmpty()) return message.failWithReason("was missing");
+
+  return message
+    .metadata({
+      Match: message.encode(match[0]),
+    })
+    .pass();
 };
 
 declare module "@rbxts/expect" {
   interface Assertion<T> {
     /**
-     * Asserts that the string value contains the string `str`.
+     * Asserts that the `expectedValue` is a string that contains
+     * a match for the provided lua `pattern`.
      *
-     * @param str - A string that should be within the value.
+     * @param pattern - A [roblox string pattern](https://create.roblox.com/docs/luau/strings#string-pattern-reference) that
+     * the actual string should have a valid match for.
      *
      * @example
      * ```ts
-     * expect("daymon").to.have.the.substring("day");
+     * expect("Daymon").to.have.the.pattern("^%u");
      * ```
      *
-     * @see {@link Assertion.pattern | pattern}
+     * @see {@link Assertion.substring | substring}
      *
      * @public
      */
-    substring(str: string): Assertion<T>;
+    pattern(pattern: string): this;
   }
 }
 
 extendMethods({
-  substring: substring,
+  pattern: hasPattern,
 });

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -1167,6 +1167,17 @@ Asserts that the value is _shallow_ equal to one of the provided `values`<!-- --
 </td></tr>
 <tr><td>
 
+[pattern(pattern)](./expect.assertion.pattern.md)
+
+
+</td><td>
+
+Asserts that the `expectedValue` is a string that contains a match for the provided lua `pattern`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [size(size)](./expect.assertion.size.md)
 
 

--- a/wiki/docs/api/expect.assertion.pattern.md
+++ b/wiki/docs/api/expect.assertion.pattern.md
@@ -1,0 +1,63 @@
+---
+id: expect.assertion.pattern
+title: Assertion.pattern() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [pattern](./expect.assertion.pattern.md)
+
+## Assertion.pattern() method
+
+Asserts that the `expectedValue` is a string that contains a match for the provided lua `pattern`<!-- -->.
+
+**Signature:**
+
+```typescript
+pattern(pattern: string): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+pattern
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+A [roblox string pattern](https://create.roblox.com/docs/luau/strings#string-pattern-reference) that the actual string should have a valid match for.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect("Daymon").to.have.the.pattern("^%u");
+```

--- a/wiki/docs/matchers/strings.mdx
+++ b/wiki/docs/matchers/strings.mdx
@@ -25,11 +25,20 @@ Expected "your name" to have the substring "my"
 
 ### Pattern
 
-:::info
+You can use the [pattern](/docs/api/expect.assertion.pattern.md) method to check if a string contains a match for a
+[roblox string pattern](https://create.roblox.com/docs/luau/strings#string-pattern-reference).
 
-[GitHub Issue #18](https://github.com/daymxn/rbxts-expect/issues/18)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect("Hello World").to.have.the.pattern("%u%l");
+```
+
+#### Example error
+
+```logs
+Expected "hello world" to have a match for the pattern /%u%l/, but it was missing
+```
 
 ### Empty
 


### PR DESCRIPTION
Adds support for the `pattern` matcher to check if a string contains a match for a roblox string pattern.

Fixes #18 