### PR TITLE
Add the `match` matcher

### DIFF
--- a/.changeset/fresh-jokes-mate.md
+++ b/.changeset/fresh-jokes-mate.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `match` and `matches` matchers

--- a/.changeset/gentle-kids-boil.md
+++ b/.changeset/gentle-kids-boil.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `matchExactly` matcher as an alias for `deepEqual`

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -76,6 +76,9 @@ export interface Assertion<T = unknown> {
     lessThanOrEqualTo(value: number): Assertion<number>;
     lt(value: number): Assertion<number>;
     lte(value: number): Assertion<number>;
+    match<R extends object>(expected: R): Assertion<R & T>;
+    matches<R extends object>(expected: R): Assertion<R & T>;
+    matchExactly<R = T>(expectedValue: R): Assertion<R>;
     most(value: number): Assertion<number>;
     // @internal (undocumented)
     _negated: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@rbxts/deep-equal": "^0.8.0",
+				"@rbxts/deep-equal": "^0.8.1",
 				"@rbxts/object-utils": "^1.0.4",
 				"@rbxts/reverse-array": "^1.0.3",
 				"@rbxts/rust-classes": "^0.12.0-dev-b01f73c",
@@ -1276,9 +1276,9 @@
 			"dev": true
 		},
 		"node_modules/@rbxts/deep-equal": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@rbxts/deep-equal/-/deep-equal-0.8.0.tgz",
-			"integrity": "sha512-XjLQjR8y6g9WNiEjR2XGJ+u5LIUfETAO+zaIJvUqSiMAO4AlG0YiIfBez+U8zGyHAX0TAZChUmkOAH7zvycrug==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@rbxts/deep-equal/-/deep-equal-0.8.1.tgz",
+			"integrity": "sha512-Gy+OcPn3qbBKNc6niwnvKgCRFoYZcadDTtRS2BoVEWjZDtIR9yz/fX0froS0aaNEyq4vsxAAiGPf/BIEy70O9A==",
 			"dependencies": {
 				"@rbxts/object-utils": "^1.0.4",
 				"@rbxts/rust-classes": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"typescript": "=5.5.3"
 	},
 	"dependencies": {
-		"@rbxts/deep-equal": "^0.8.0",
+		"@rbxts/deep-equal": "^0.8.1",
 		"@rbxts/object-utils": "^1.0.4",
 		"@rbxts/reverse-array": "^1.0.3",
 		"@rbxts/rust-classes": "^0.12.0-dev-b01f73c",

--- a/src/expect/extensions/deep-equal/index.ts
+++ b/src/expect/extensions/deep-equal/index.ts
@@ -212,6 +212,16 @@ declare module "@rbxts/expect" {
      *
      * @public
      */
+    matchExactly<R = T>(expectedValue: R): Assertion<R>;
+
+    /**
+     * Asserts that the value is _deep_ equal to the `expectedValue`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.deepEqual | deepEqual}_
+     *
+     * @public
+     */
     deepEquals<R = T>(expectedValue: R): Assertion<R>;
 
     /**
@@ -229,5 +239,6 @@ declare module "@rbxts/expect" {
 extendMethods({
   deepEquals: eql,
   deepEqual: eql,
+  matchExactly: eql,
   eql: eql,
 });

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -29,6 +29,7 @@ import "./even-odd";
 import "./include";
 import "./instance-of";
 import "./length";
+import "./match";
 import "./negations";
 import "./noops";
 import "./number-comparators";

--- a/src/expect/extensions/match/index.spec.ts
+++ b/src/expect/extensions/match/index.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  expect,
+  resetDefaultExpectConfig,
+  setDefaultExpectConfig,
+} from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("matches", () => {
+    it("works with objects", () => {
+      expect(TEST_SON).to.match({ age: 4 }).but.not.match({ name: "Daymon" });
+    });
+
+    it("allows extra elements in tables", () => {
+      expect({
+        name: "Daymon",
+        cars: ["Tesla", "Civic"],
+      }).to.match({
+        cars: ["Tesla"],
+      });
+    });
+
+    it("allows extra keys", () => {
+      expect({
+        name: "Daymon",
+        age: "5",
+      }).to.match({
+        name: "Daymon",
+      });
+    });
+  });
+
+  describe("error message", () => {
+    beforeAll(() => {
+      setDefaultExpectConfig({ collapseLength: 0 });
+    });
+
+    afterAll(() => {
+      resetDefaultExpectConfig();
+    });
+
+    it("throws if table paths have different types", () => {
+      err(
+        () => {
+          expect({
+            name: "Daymon",
+            age: 5,
+          }).to.match({
+            age: "5",
+          });
+        },
+        `Expected '{...}' to match '{...}', but 'age' has a different type`,
+        'Expected: "5" (string)',
+        "Actual: '5' (number)",
+        `Expected (full):`,
+        "Actual (full):"
+      );
+    });
+
+    it("throws if table paths have different values", () => {
+      err(
+        () => {
+          expect({
+            name: "Daymon",
+            age: 5,
+          }).to.match({
+            age: 4,
+          });
+        },
+        `Expected '{...}' to match '{...}', but 'age' has a different value`,
+        "Expected: '4' (number)",
+        "Actual: '5' (number)",
+        `Expected (full):`,
+        "Actual (full):"
+      );
+    });
+
+    it("throws if table paths have different values by reference", () => {
+      err(
+        () => {
+          expect({
+            name: "Daymon",
+            car: new Instance("Part"),
+          }).to.match({
+            car: new Instance("Part"),
+          });
+        },
+        `Expected '{...}' to match '{...}', but 'car' points to a different value of reference type 'Instance'`,
+        `Expected (full):`,
+        "Actual (full):"
+      );
+    });
+
+    it("throws if there are elements missing from arrays in tables", () => {
+      err(
+        () => {
+          expect({
+            name: "Daymon",
+            cars: ["Tesla"],
+          }).to.match({
+            cars: ["Tesla", "Civic"],
+          });
+        },
+        `Expected '{...}' to match '{...}', but 'cars' was missing some elements`,
+        `Expected: '["Tesla","Civic"]'`,
+        `Actual: '["Tesla"]'`,
+        `Missing: '["Civic"]'`,
+        `Expected (full):`,
+        "Actual (full):"
+      );
+    });
+
+    it("throws if there's keys missing", () => {
+      err(
+        () => {
+          expect({
+            name: "Daymon",
+          }).to.match({
+            name: "Daymon",
+            age: "5",
+          });
+        },
+        `Expected '{...}' to match '{...}', but 'age' was missing`,
+        'Expected: "5" (string)',
+        "Expected (full):"
+      );
+    });
+
+    it("works with proxy paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent).to.match({ age: 20 });
+          });
+        },
+        `Expected parent to match '{...}', but 'age' has a different value`,
+        `Expected: '20' (number)`,
+        "Actual: '5' (number)",
+        "Expected (full):",
+        "Actual (full):"
+      );
+    });
+  });
+};

--- a/src/expect/extensions/match/index.ts
+++ b/src/expect/extensions/match/index.ts
@@ -15,5 +15,211 @@
  * limitations under the License.
  */
 
-// TODO: compares two objects to see if the values on the right are all in the left and equal the same
-// also support matchExactly for matching both ways (wouldn't this just be deepEqual) though? so probably an alias for deep equal
+import { deepEqual, FailureType } from "@rbxts/deep-equal";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+import { isProxy } from "@src/util/proxy";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} match ${place.expected.value}`
+);
+
+const match: CustomMethodImpl = (_, actual, expected: object) => {
+  const message = baseMessage.use().expectedValue(expected);
+
+  if (isProxy(expected)) {
+    warn(
+      "Using proxies on the right side of assertions is undefined behavior. For further context, see http://rbxts-expect.daymxn.com/docs/usage-guide#proxies"
+    );
+  }
+
+  const result = deepEqual(actual, expected, { checkRightMissing: false });
+
+  if (!result) return message.pass();
+
+  switch (result.failType) {
+    case FailureType.DIFFERENT_REFERENCE: {
+      if (result.path === "") {
+        return message
+          .suffix(
+            `, but they point to different values of reference type '${place.actual.type}'`
+          )
+          .metadata({
+            Actual: place.actual.value,
+            Expected: place.expected.value,
+          })
+          .fail();
+      } else {
+        return message
+          .suffix(
+            `, but '${result.path}' points to a different value of reference type '${result.leftType}'`
+          )
+          .metadata({
+            Actual: message.encode(result.leftValue),
+            Expected: message.encode(result.rightValue),
+          })
+          .fail();
+      }
+    }
+    case FailureType.DIFFERENT_TYPES: {
+      if (result.path === "") {
+        return message
+          .suffix(`, but they have different types`)
+          .metadata({
+            Actual: `${place.actual.value} (${place.actual.type})`,
+            Expected: `${place.expected.value} (${place.expected.type})`,
+          })
+          .fail();
+      } else {
+        return message
+          .suffix(`, but '${result.path}' has a different type`)
+          .metadata({
+            Actual: `${message.encode(result.leftValue)} (${result.leftType})`,
+            Expected: `${message.encode(result.rightValue)} (${result.rightType})`,
+          })
+          .fail();
+      }
+    }
+    case FailureType.DIFFERENT_VALUES: {
+      if (result.path === "") {
+        return message
+          .suffix(`, but they have different values`)
+          .metadata({
+            Actual: `${place.actual.value} (${place.actual.type})`,
+            Expected: `${place.expected.value} (${place.expected.type})`,
+          })
+          .fail();
+      } else {
+        return message
+          .suffix(`, but '${result.path}' has a different value`)
+          .metadata({
+            Actual: `${message.encode(result.leftValue)} (${result.leftType})`,
+            Expected: `${message.encode(result.rightValue)} (${result.rightType})`,
+          })
+          .fail();
+      }
+    }
+    case FailureType.MISSING_ARRAY_VALUE: {
+      if (result.path === "") {
+        if (!result.leftMissing.isEmpty()) {
+          return message
+            .suffix(`, but there were elements missing`)
+            .metadata({
+              Actual: `${place.actual.value}`,
+              Expected: `${place.expected.value}`,
+              Missing: message.encode(result.leftMissing),
+            })
+            .fail();
+        } else {
+          return message
+            .suffix(`, but there were extra elements`)
+            .metadata({
+              Actual: `${place.actual.value}`,
+              Expected: `${place.expected.value}`,
+              [`Extra Elements`]: message.encode(result.rightMissing),
+            })
+            .fail();
+        }
+      } else {
+        if (!result.leftMissing.isEmpty()) {
+          return message
+            .suffix(`, but '${result.path}' was missing some elements`)
+            .metadata({
+              Actual: message.encode(result.leftValue),
+              Expected: message.encode(result.rightValue),
+              Missing: message.encode(result.leftMissing),
+            })
+            .fail();
+        } else {
+          return message
+            .suffix(`, but '${result.path}' had extra elements`)
+            .metadata({
+              Actual: message.encode(result.leftValue),
+              Expected: message.encode(result.rightValue),
+              [`Extra Elements`]: message.encode(result.rightMissing),
+            })
+            .fail();
+        }
+      }
+    }
+    case FailureType.MISSING: {
+      if (result.leftValue === undefined) {
+        return message
+          .suffix(`, but '${result.path}' was missing`)
+          .metadata({
+            Expected: `${message.encode(result.rightValue)} (${result.rightType})`,
+          })
+          .fail();
+      } else {
+        return message
+          .suffix(`, but it had the extra key '${result.path}'`)
+          .metadata({
+            [result.path]: `${message.encode(result.leftValue)} (${result.leftType})`,
+          })
+          .fail();
+      }
+    }
+  }
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the actual value has the same properties and values
+     * as the `expected`.
+     *
+     * @remarks
+     * Very similar to {@link Assertion.deepEqual | deepEqual}, but this only
+     * applies one way; it doesn't fail if there are extra keys.
+     *
+     * Can be used to only check a collection of certain keys and their respective
+     * values.
+     *
+     * @example
+     * ```ts
+     * expect({
+     *   name: "daymon",
+     *   age: 24
+     *   children: [{
+     *     name: "michael",
+     *     age: 4
+     *   }]
+     * }).to.match({ age: 24 });
+     * ```
+     *
+     * @see {@link Assertion.matches | matches}
+     *
+     * @public
+     */
+    match<R extends object>(expected: R): Assertion<R & T>;
+
+    /**
+     * Asserts that the actual value has the same properties and values
+     * as the `expected`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.match | match}._
+     *
+     * @example
+     * ```ts
+     * expect({
+     *   name: "daymon",
+     *   age: 24
+     *   children: [{
+     *     name: "michael",
+     *     age: 4
+     *   }]
+     * }).to.be.an.object().that.matches({ age: 24 });
+     * ```
+     *
+     * @public
+     */
+    matches<R extends object>(expected: R): Assertion<R & T>;
+  }
+}
+
+extendMethods({
+  match: match,
+  matches: match,
+});

--- a/wiki/docs/api/expect.assertion.match.md
+++ b/wiki/docs/api/expect.assertion.match.md
@@ -1,0 +1,74 @@
+---
+id: expect.assertion.match
+title: Assertion.match() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [match](./expect.assertion.match.md)
+
+## Assertion.match() method
+
+Asserts that the actual value has the same properties and values as the `expected`<!-- -->.
+
+**Signature:**
+
+```typescript
+match<R extends object>(expected: R): Assertion<R & T>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+expected
+
+
+</td><td>
+
+R
+
+
+</td><td>
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;R &amp; T&gt;
+
+## Remarks
+
+Very similar to [deepEqual](./expect.assertion.deepequal.md)<!-- -->, but this only applies one way; it doesn't fail if there are extra keys.
+
+Can be used to only check a collection of certain keys and their respective values.
+
+## Example
+
+
+```ts
+expect({
+  name: "daymon",
+  age: 24
+  children: [{
+    name: "michael",
+    age: 4
+  }]
+}).to.match({ age: 24 });
+```

--- a/wiki/docs/api/expect.assertion.matches.md
+++ b/wiki/docs/api/expect.assertion.matches.md
@@ -1,0 +1,72 @@
+---
+id: expect.assertion.matches
+title: Assertion.matches() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [matches](./expect.assertion.matches.md)
+
+## Assertion.matches() method
+
+Asserts that the actual value has the same properties and values as the `expected`<!-- -->.
+
+**Signature:**
+
+```typescript
+matches<R extends object>(expected: R): Assertion<R & T>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+expected
+
+
+</td><td>
+
+R
+
+
+</td><td>
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;R &amp; T&gt;
+
+## Remarks
+
+_Type alias for [match](./expect.assertion.match.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect({
+  name: "daymon",
+  age: 24
+  children: [{
+    name: "michael",
+    age: 4
+  }]
+}).to.be.an.object().that.matches({ age: 24 });
+```

--- a/wiki/docs/api/expect.assertion.matchexactly.md
+++ b/wiki/docs/api/expect.assertion.matchexactly.md
@@ -1,0 +1,58 @@
+---
+id: expect.assertion.matchexactly
+title: Assertion.matchExactly() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [matchExactly](./expect.assertion.matchexactly.md)
+
+## Assertion.matchExactly() method
+
+Asserts that the value is _deep_ equal to the `expectedValue`<!-- -->.
+
+**Signature:**
+
+```typescript
+matchExactly<R = T>(expectedValue: R): Assertion<R>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+expectedValue
+
+
+</td><td>
+
+R
+
+
+</td><td>
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;R&gt;
+
+## Remarks
+
+_Type alias for [deepEqual](./expect.assertion.deepequal.md)<!-- -->_

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -1079,6 +1079,39 @@ Asserts that the value is less than or equal to `value`<!-- -->.
 </td></tr>
 <tr><td>
 
+[match(expected)](./expect.assertion.match.md)
+
+
+</td><td>
+
+Asserts that the actual value has the same properties and values as the `expected`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[matches(expected)](./expect.assertion.matches.md)
+
+
+</td><td>
+
+Asserts that the actual value has the same properties and values as the `expected`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[matchExactly(expectedValue)](./expect.assertion.matchexactly.md)
+
+
+</td><td>
+
+Asserts that the value is _deep_ equal to the `expectedValue`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [most(value)](./expect.assertion.most.md)
 
 

--- a/wiki/docs/matchers/objects.mdx
+++ b/wiki/docs/matchers/objects.mdx
@@ -94,11 +94,31 @@ Actual (full): '{"name":"Daymon","age":5}'
 
 ### Match
 
-:::info
+You can use the [match](/docs/api/expect.assertion.match.md) method to check if an object has a collection of certain
+keys with certain values.
 
-[GitHub Issue #19](https://github.com/daymxn/rbxts-expect/issues/19)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect({
+  name: "Daymon",
+  age: 5,
+}).to.match({
+  age: 5,
+});
+```
+
+#### Example error
+
+```logs
+Expected '{...}' to match '{...}', but 'age' has a different value
+
+Expected: '4' (number)
+Actual: '5' (number)
+
+Expected (full): '{"age":4}'
+Actual (full): '{"name":"Daymon","age":5}'
+```
 
 ### Key/Property
 


### PR DESCRIPTION
Adds support for the `match` matcher for checking if an object contains a subset of keys with certain values.

Effectively a version of `deepEqual` that doesn't check for missing keys in the expected variable.

Fixes #19 