### PR TITLE
Add `near` matcher

### DIFF
--- a/.changeset/small-walls-learn.md
+++ b/.changeset/small-walls-learn.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `near` and `closeTo` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -36,6 +36,8 @@ export interface Assertion<T = unknown> {
     between(minValue: number, maxValue: number): Assertion<number>;
     boolean(): Assertion<boolean>;
     readonly but: this;
+    closeTo(value: number): Assertion<number>;
+    closeTo(value: number, margin: number): Assertion<number>;
     containExactly(expectedValues: InferArrayElement<T>[]): this;
     containExactlyInOrder(expectedValues: InferArrayElement<T>[]): this;
     containsExactly(expectedValues: InferArrayElement<T>[]): this;
@@ -80,6 +82,8 @@ export interface Assertion<T = unknown> {
     matches<R extends object>(expected: R): Assertion<R & T>;
     matchExactly<R = T>(expectedValue: R): Assertion<R>;
     most(value: number): Assertion<number>;
+    near(value: number): Assertion<number>;
+    near(value: number, margin: number): Assertion<number>;
     // @internal (undocumented)
     _negated: boolean;
     readonly never: this;

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -30,6 +30,7 @@ import "./include";
 import "./instance-of";
 import "./length";
 import "./match";
+import "./near";
 import "./negations";
 import "./noops";
 import "./number-comparators";

--- a/src/expect/extensions/near/index.spec.ts
+++ b/src/expect/extensions/near/index.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+const EPSILON = 2.220446049250313e-16;
+
+export = () => {
+  describe("near", () => {
+    it("checks if the value is within a range", () => {
+      expect(5 - EPSILON)
+        .to.be.near(5)
+        .and.closeTo(6, 2)
+        .but.not.near(5 - 0.1)
+        .or.closeTo(-5);
+    });
+
+    it("inclusively checks if the value is within a range", () => {
+      expect(5).to.be.closeTo(5);
+      expect(5.1).to.be.near(5, 0.1);
+    });
+
+    it("works with negative numbers", () => {
+      expect(-5 + EPSILON).to.be.closeTo(-5);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the value is too big", () => {
+      err(() => {
+        expect(1).to.be.near(0);
+      }, "Expected '1' to be a number close to '0', but it was too high");
+    });
+
+    it("throws when the value is too small", () => {
+      err(() => {
+        expect(0).to.be.near(1);
+      }, "Expected '0' to be a number close to '1', but it was too low");
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.be.near(1);
+      }, "Expected the value to be a number close to '1', but it was undefined");
+    });
+
+    it("throws when it's not a number", () => {
+      err(() => {
+        expect("5").to.be.near(1);
+      }, `Expected "5" (string) to be a number close to '1', but it wasn't a number`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.near(25);
+          });
+        },
+        `Expected parent.age to be a number close to '25', but it was too low`,
+        `parent.age: '5'`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/near/index.ts
+++ b/src/expect/extensions/near/index.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const EPSILON = 2.220446049250313e-16;
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be a number close to ${place.expected.value}`
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .negationSuffix(", but it was")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+const near: CustomMethodImpl = (
+  _,
+  actual,
+  target: number,
+  margin: number = EPSILON
+) => {
+  const message = baseMessage.use().expectedValue(target);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "number")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a number");
+  }
+
+  const difference = target - actual;
+
+  if (math.abs(difference) <= margin) return message.pass();
+
+  return difference > 0
+    ? message.failWithReason("was too low")
+    : message.failWithReason("was too high");
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the actual value is a number within epsilon of `value`.
+     *
+     * @remarks
+     * An epsilon is the smallest number representable by a 64 bit double.
+     *
+     * Specifically, this method uses the IEEE 754 standard of `2.220446049250313e-16`.
+     *
+     * @param value - The number that the actual value should be within epsilon of.
+     *
+     * @example
+     * ```ts
+     * const epsilon = 2.220446049250313e-16;
+     * expect(10-epsilon).to.be.near(10);
+     * ```
+     *
+     * @see {@link Assertion.closeTo | closeTo}
+     *
+     * @public
+     */
+    near(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the actual value is a number within `margin` of `value`.
+     *
+     * @remarks
+     * The margin is considered _inclusive_; if the actual value is exactly
+     * `value` +- `margin` then it's considered a pass.
+     *
+     * @param value - The number that the actual value should be `margin` of.
+     * @param margin - A range of which the actual value should be +-`value` in.
+     *
+     * @example
+     * ```ts
+     * expect(11).to.be.near(10, 1);
+     * expect(100).to.be.near(125, 50);
+     * expect(5.005).to.be.near(5, .01)
+     * ```
+     *
+     * @see {@link Assertion.closeTo | closeTo}
+     *
+     * @public
+     */
+    near(value: number, margin: number): Assertion<number>;
+
+    /**
+     * Asserts that the actual value is a number within epsilon of `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.near | near}._
+     *
+     * @param value - The number that the actual value should be within epsilon of.
+     *
+     * @example
+     * ```ts
+     * const epsilon = 2.220446049250313e-16;
+     * expect(10-epsilon).to.be.closeTo(10);
+     * ```
+     *
+     * @public
+     */
+    closeTo(value: number): Assertion<number>;
+
+    /**
+     * Asserts that the actual value is a number within `margin` of `value`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.near | near}._
+     *
+     * @param value - The number that the actual value should be `margin` of.
+     * @param margin - A range of which the actual value should be +-`value` in.
+     *
+     * @example
+     * ```ts
+     * expect(11).to.be.closeTo(10, 1);
+     * expect(100).to.be.closeTo(125, 50);
+     * expect(5.005).to.be.closeTo(5, .01)
+     * ```
+     *
+     * @public
+     */
+    closeTo(value: number, margin: number): Assertion<number>;
+  }
+}
+
+extendMethods({
+  near: near,
+  closeTo: near,
+});

--- a/wiki/docs/api/expect.assertion.closeto.md
+++ b/wiki/docs/api/expect.assertion.closeto.md
@@ -1,0 +1,68 @@
+---
+id: expect.assertion.closeto
+title: Assertion.closeTo() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [closeTo](./expect.assertion.closeto.md)
+
+## Assertion.closeTo() method
+
+Asserts that the actual value is a number within epsilon of `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+closeTo(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The number that the actual value should be within epsilon of.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for ._
+
+## Example
+
+
+```ts
+const epsilon = 2.220446049250313e-16;
+expect(10-epsilon).to.be.closeTo(10);
+```

--- a/wiki/docs/api/expect.assertion.closeto_1.md
+++ b/wiki/docs/api/expect.assertion.closeto_1.md
@@ -1,0 +1,85 @@
+---
+id: expect.assertion.closeto_1
+title: Assertion.closeTo() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [closeTo](./expect.assertion.closeto_1.md)
+
+## Assertion.closeTo() method
+
+Asserts that the actual value is a number within `margin` of `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+closeTo(value: number, margin: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The number that the actual value should be `margin` of.
+
+
+</td></tr>
+<tr><td>
+
+margin
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A range of which the actual value should be +-`value` in.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+_Type alias for ._
+
+## Example
+
+
+```ts
+expect(11).to.be.closeTo(10, 1);
+expect(100).to.be.closeTo(125, 50);
+expect(5.005).to.be.closeTo(5, .01)
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -694,6 +694,28 @@ Asserts that the value is a [boolean](https://create.roblox.com/docs/luau/boolea
 </td></tr>
 <tr><td>
 
+[closeTo(value)](./expect.assertion.closeto.md)
+
+
+</td><td>
+
+Asserts that the actual value is a number within epsilon of `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[closeTo(value, margin)](./expect.assertion.closeto_1.md)
+
+
+</td><td>
+
+Asserts that the actual value is a number within `margin` of `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [containExactly(expectedValues)](./expect.assertion.containexactly.md)
 
 
@@ -1118,6 +1140,28 @@ Asserts that the value is _deep_ equal to the `expectedValue`<!-- -->.
 </td><td>
 
 Asserts that the value is less than or equal to `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[near(value)](./expect.assertion.near.md)
+
+
+</td><td>
+
+Asserts that the actual value is a number within epsilon of `value`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[near(value, margin)](./expect.assertion.near_1.md)
+
+
+</td><td>
+
+Asserts that the actual value is a number within `margin` of `value`<!-- -->.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.near.md
+++ b/wiki/docs/api/expect.assertion.near.md
@@ -1,0 +1,70 @@
+---
+id: expect.assertion.near
+title: Assertion.near() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [near](./expect.assertion.near.md)
+
+## Assertion.near() method
+
+Asserts that the actual value is a number within epsilon of `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+near(value: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The number that the actual value should be within epsilon of.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+An epsilon is the smallest number representable by a 64 bit double.
+
+Specifically, this method uses the IEEE 754 standard of `2.220446049250313e-16`<!-- -->.
+
+## Example
+
+
+```ts
+const epsilon = 2.220446049250313e-16;
+expect(10-epsilon).to.be.near(10);
+```

--- a/wiki/docs/api/expect.assertion.near_1.md
+++ b/wiki/docs/api/expect.assertion.near_1.md
@@ -1,0 +1,85 @@
+---
+id: expect.assertion.near_1
+title: Assertion.near() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [near](./expect.assertion.near_1.md)
+
+## Assertion.near() method
+
+Asserts that the actual value is a number within `margin` of `value`<!-- -->.
+
+**Signature:**
+
+```typescript
+near(value: number, margin: number): Assertion<number>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+The number that the actual value should be `margin` of.
+
+
+</td></tr>
+<tr><td>
+
+margin
+
+
+</td><td>
+
+number
+
+
+</td><td>
+
+A range of which the actual value should be +-`value` in.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+The margin is considered _inclusive_; if the actual value is exactly `value` +- `margin` then it's considered a pass.
+
+## Example
+
+
+```ts
+expect(11).to.be.near(10, 1);
+expect(100).to.be.near(125, 50);
+expect(5.005).to.be.near(5, .01)
+```

--- a/wiki/docs/matchers/numbers.mdx
+++ b/wiki/docs/matchers/numbers.mdx
@@ -160,10 +160,25 @@ Expected '10' to be a number between 5 and 8, but it was too high.
 
 :::
 
-### Close to
+### Near
 
-:::info
+You can use the [near](/docs/api/expect.assertion.near.md) or [closeTo](/docs/api/expect.assertion.closeto.md) methods
+to check if a number is within a margin of another.
 
-[GitHub Issue #6](https://github.com/daymxn/rbxts-expect/issues/6)
+When a margin isn't specified, epsilon is used instead (per
+[IEEE 754 float64](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)).
 
-:::
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(5).to.be.near(5 + 1e-8);
+expect(1.5).to.be.near(1, 0.5);
+expect(math.pi).to.be.near(3, 0.2);
+expect(-10).to.be.closeTo(0, 15);
+```
+
+#### Example error
+
+```logs
+Expected '1' to be a number close to '0', but it was too high
+```


### PR DESCRIPTION
Adds support for the matchers `near` and `closeTo` to check if a number is within a margin (or epsilon) of another.

Fixes #6 