### PR TITLE
Added `positive` and `negative` matchers

### DIFF
--- a/.changeset/eighty-maps-approve.md
+++ b/.changeset/eighty-maps-approve.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `positive` and `negative` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -86,6 +86,7 @@ export interface Assertion<T = unknown> {
     near(value: number, margin: number): Assertion<number>;
     // @internal (undocumented)
     _negated: boolean;
+    negative(): Assertion<number>;
     readonly never: this;
     nil(): this;
     readonly not: this;
@@ -98,6 +99,7 @@ export interface Assertion<T = unknown> {
     oneOf<R = T>(values: R[]): Assertion<R>;
     readonly or: this;
     pattern(pattern: string): this;
+    positive(): Assertion<number>;
     // @internal (undocumented)
     _proxy?: Proxy<T>;
     // @internal (undocumented)

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -35,6 +35,7 @@ import "./negations";
 import "./noops";
 import "./number-comparators";
 import "./pattern";
+import "./positive-negative";
 import "./some";
 import "./substring";
 import "./throws";

--- a/src/expect/extensions/positive-negative/index.spec.ts
+++ b/src/expect/extensions/positive-negative/index.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("positive", () => {
+    it("checks if the value is greater than zero", () => {
+      expect(5).to.be.positive();
+    });
+
+    it("fails when zero", () => {
+      expect(0).to.not.be.positive();
+    });
+  });
+
+  describe("negative", () => {
+    it("checks if the value is less than zero", () => {
+      expect(-5).to.be.negative();
+    });
+
+    it("fails when zero", () => {
+      expect(0).to.not.be.negative();
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the check fails", () => {
+      err(() => {
+        expect(-1).to.be.positive();
+      }, "Expected '-1' to be a positive number, but it was negative");
+
+      err(() => {
+        expect(1).to.be.negative();
+      }, "Expected '1' to be a negative number, but it was positive");
+    });
+
+    it("throws when it's zero", () => {
+      err(() => {
+        expect(0).to.be.positive();
+      }, "Expected '0' to be a positive number, but it was neutral");
+
+      err(() => {
+        expect(0).to.be.negative();
+      }, "Expected '0' to be a negative number, but it was neutral");
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.be.positive();
+      }, "Expected the value to be a positive number, but it was undefined");
+
+      err(() => {
+        expect(undefined).to.be.negative();
+      }, "Expected the value to be a negative number, but it was undefined");
+    });
+
+    it("throws when it's not a number", () => {
+      err(() => {
+        expect("5").to.be.positive();
+      }, `Expected "5" (string) to be a positive number, but it wasn't a number`);
+
+      err(() => {
+        expect("5").to.be.negative();
+      }, `Expected "5" (string) to be a negative number, but it wasn't a number`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.be.negative();
+          });
+        },
+        `Expected parent.age to be a negative number, but it was positive`,
+        `parent.age: '5'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.age).to.not.be.positive();
+          });
+        },
+        `Expected parent.age to NOT be a positive number, but it was`,
+        `parent.age: '5'`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/positive-negative/index.ts
+++ b/src/expect/extensions/positive-negative/index.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be a `
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .negationSuffix(", but it was")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+function verifyComparison(
+  message: ExpectMessageBuilder,
+  actual: unknown,
+  positive: boolean
+) {
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "number")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a number");
+  }
+
+  if (actual === 0) return message.failWithReason("was neutral");
+
+  if (positive) {
+    return actual > 0 ? message.pass() : message.fail();
+  } else {
+    return actual < 0 ? message.pass() : message.fail();
+  }
+}
+
+const positive: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`positive number`).reason("was negative");
+
+  return verifyComparison(message, actual, true);
+};
+
+const negative: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`negative number`).reason("was positive");
+
+  return verifyComparison(message, actual, false);
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the value is a positive number.
+     *
+     * @remarks
+     * A positive number is any number greater than zero.
+     *
+     * @example
+     * ```ts
+     * expect(1).to.be.positive();
+     *
+     * expect(0).to.not.be.positive();
+     * expect(-1).to.not.be.positive();
+     * ```
+     *
+     * @see {@link Assertion.negative | negative}
+     *
+     * @public
+     */
+    positive(): Assertion<number>;
+
+    /**
+     * Asserts that the value is a negative number.
+     *
+     * @remarks
+     * A negative number is any number less than zero.
+     *
+     * @example
+     * ```ts
+     * expect(-1).to.be.negative();
+     *
+     * expect(0).to.not.be.negative();
+     * expect(1).to.not.be.negative();
+     * ```
+     *
+     * @see {@link Assertion.positive | positive}
+     *
+     * @public
+     */
+    negative(): Assertion<number>;
+  }
+}
+
+extendMethods({
+  positive: positive,
+  negative: negative,
+});

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -1167,6 +1167,17 @@ Asserts that the actual value is a number within `margin` of `value`<!-- -->.
 </td></tr>
 <tr><td>
 
+[negative()](./expect.assertion.negative.md)
+
+
+</td><td>
+
+Asserts that the value is a negative number.
+
+
+</td></tr>
+<tr><td>
+
 [nil()](./expect.assertion.nil.md)
 
 
@@ -1250,6 +1261,17 @@ Asserts that the value is _shallow_ equal to one of the provided `values`<!-- --
 </td><td>
 
 Asserts that the `expectedValue` is a string that contains a match for the provided lua `pattern`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[positive()](./expect.assertion.positive.md)
+
+
+</td><td>
+
+Asserts that the value is a positive number.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.negative.md
+++ b/wiki/docs/api/expect.assertion.negative.md
@@ -1,0 +1,34 @@
+---
+id: expect.assertion.negative
+title: Assertion.negative() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [negative](./expect.assertion.negative.md)
+
+## Assertion.negative() method
+
+Asserts that the value is a negative number.
+
+**Signature:**
+
+```typescript
+negative(): Assertion<number>;
+```
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+A negative number is any number less than zero.
+
+## Example
+
+
+```ts
+expect(-1).to.be.negative();
+
+expect(0).to.not.be.negative();
+expect(1).to.not.be.negative();
+```

--- a/wiki/docs/api/expect.assertion.positive.md
+++ b/wiki/docs/api/expect.assertion.positive.md
@@ -1,0 +1,34 @@
+---
+id: expect.assertion.positive
+title: Assertion.positive() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [positive](./expect.assertion.positive.md)
+
+## Assertion.positive() method
+
+Asserts that the value is a positive number.
+
+**Signature:**
+
+```typescript
+positive(): Assertion<number>;
+```
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+A positive number is any number greater than zero.
+
+## Example
+
+
+```ts
+expect(1).to.be.positive();
+
+expect(0).to.not.be.positive();
+expect(-1).to.not.be.positive();
+```

--- a/wiki/docs/matchers/numbers.mdx
+++ b/wiki/docs/matchers/numbers.mdx
@@ -83,19 +83,41 @@ Expected '2' to be less than or equal to '1'
 
 ### Negative
 
-:::info
+You can use the [negative](/docs/api/expect.assertion.negative.md) method to check if a number is less than zero.
 
-[GitHub Issue #9](https://github.com/daymxn/rbxts-expect/issues/9)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect(-5).to.be.negative();
+
+expect(0).to.not.be.negative();
+expect(5).to.not.be.negative();
+```
+
+#### Example error
+
+```logs
+Expected '1' to be a negative number, but it was positive
+```
 
 ### Positive
 
-:::info
+You can use the [positive](/docs/api/expect.assertion.positive.md) method to check if a number is greater than zero.
 
-[GitHub Issue #9](https://github.com/daymxn/rbxts-expect/issues/9)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect(5).to.be.positive();
+
+expect(0).to.not.be.positive();
+expect(-5).to.not.be.positive();
+```
+
+#### Example error
+
+```logs
+Expected '-1' to be a positive number, but it was negative
+```
 
 ### Even
 


### PR DESCRIPTION
Adds the `positive` and `negative` matchers to check if a number is greater or less than zero. Zero is treated as neutral, and fails both positive and negative checks. If folks want to check for non negative values they should just do `expect(1).to.be.a.number().that.is.not.negative()` or something akin.

Fixes #9 