### PR TITLE
Add the `startWith` matcher

### DIFF
--- a/.changeset/dull-lies-help.md
+++ b/.changeset/dull-lies-help.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": patch
+---
+
+Fixed an issue where `length` wasn't properly checking empty arrays and objects

--- a/.changeset/long-dancers-exist.md
+++ b/.changeset/long-dancers-exist.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `startWith` and `startsWith` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -110,6 +110,10 @@ export interface Assertion<T = unknown> {
     sizeOf(size: number): this;
     some(condition: Filter<InferArrayElement<T>>): this;
     some(reason: string, condition: Filter<InferArrayElement<T>>): this;
+    startsWith(elements: InferArrayElement<T>[]): this;
+    startsWith(str: string): Assertion<string>;
+    startWith(elements: InferArrayElement<T>[]): this;
+    startWith(str: string): Assertion<string>;
     readonly still: this;
     string(): Assertion<string>;
     substring(str: string): Assertion<T>;

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -37,5 +37,6 @@ import "./pattern";
 import "./positive-negative";
 import "./shallow-equal";
 import "./some";
+import "./start-with";
 import "./substring";
 import "./throws";

--- a/src/expect/extensions/length/index.spec.ts
+++ b/src/expect/extensions/length/index.spec.ts
@@ -23,14 +23,16 @@ export = () => {
   describe("length", () => {
     it("checks if arrays have the given amount of elements", () => {
       expect([1, 2, 3]).to.have.size(3).but.not.size(2);
+      expect([]).to.have.size(0).but.not.size(1);
     });
 
     it("checks if strings have the given amount of characters ", () => {
       expect("12345").to.have.size(5).but.not.size(4);
+      expect("").to.have.size(0).but.not.size(1);
     });
 
     it("checks if objects have the given amount of keys", () => {
-      expect({}).to.have.size(1);
+      expect({}).to.have.size(0).but.not.size(1);
       expect({
         name: "Daymon",
         age: 5,

--- a/src/expect/extensions/length/index.ts
+++ b/src/expect/extensions/length/index.ts
@@ -47,9 +47,6 @@ function validateArrayIsSize(actual: defined[], size: number) {
     .use(`exactly ${place.expected.value} element(s)`)
     .expectedValue(size);
 
-  // TODO(): wait why am I doing this?
-  if (actual.isEmpty()) return message.pass();
-
   const actualSize = actual.size();
 
   if (actualSize === size) return message.pass();

--- a/src/expect/extensions/length/index.ts
+++ b/src/expect/extensions/length/index.ts
@@ -47,6 +47,7 @@ function validateArrayIsSize(actual: defined[], size: number) {
     .use(`exactly ${place.expected.value} element(s)`)
     .expectedValue(size);
 
+  // TODO(): wait why am I doing this?
   if (actual.isEmpty()) return message.pass();
 
   const actualSize = actual.size();

--- a/src/expect/extensions/start-with/index.spec.ts
+++ b/src/expect/extensions/start-with/index.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("startWith", () => {
+    it("checks if arrays start with the given elements", () => {
+      expect([1, 2, 3]).to.startWith([1, 2]).but.not.startWith([2, 3]);
+    });
+
+    it("checks if strings start with the given characters ", () => {
+      expect("12345").to.startWith("123").but.not.startWith("345");
+    });
+
+    it("works with empty values", () => {
+      expect([]).to.startWith([]);
+      expect("").to.startWith("");
+    });
+  });
+
+  describe("error message", () => {
+    it("throws if the array doesn't have all of the elements", () => {
+      err(() => {
+        expect([1, 2]).to.startWith([2, 3]);
+      }, `Expected '[1,2]' to be an array that starts with '[2,3]', but it was missing all of them`);
+    });
+
+    it("throws if the string doesn't have all of the elements", () => {
+      err(() => {
+        expect("day").to.startWith("mon");
+      }, `Expected "day" to be a string that starts with "mon", but it was missing`);
+    });
+
+    it("throws if the string doesn't have some of the elements", () => {
+      err(() => {
+        expect("day").to.startWith("daym");
+      }, `Expected "day" to be a string that starts with "daym", but it was missing`);
+    });
+
+    it("throws if the array is missing one of the elements", () => {
+      err(() => {
+        expect([1, 2]).to.startWith([0, 2]);
+      }, `Expected '[1,2]' to be an array that starts with '[0,2]', but it was missing '0'`);
+    });
+
+    it("throws if the array is missing multiple elements", () => {
+      err(
+        () => {
+          expect([1, 2, 3]).to.startWith([1, 4, 5]);
+        },
+        `Expected '[1,2,3]' to be an array that starts with '[1,4,5]', but it was missing 2 elements`,
+        `Missing: '[4,5]'`
+      );
+    });
+
+    it("throws if the type isn't a string", () => {
+      err(() => {
+        expect([1, 2]).to.startWith("day");
+      }, `Expected '[1,2]' (table) to be a string that starts with "day", but it wasn't a string`);
+    });
+
+    it("throws if the type isn't an array", () => {
+      err(() => {
+        expect("day" as never as number[]).to.startWith([1]);
+      }, `Expected "day" (string) to be an array that starts with '[1]', but it wasn't an array`);
+    });
+
+    it("throws if the type is undefined", () => {
+      err(() => {
+        expect(undefined).to.startWith("day");
+      }, `Expected the value to be a string that starts with "day", but it was undefined`);
+
+      err(() => {
+        expect(undefined as never as number[]).to.startWith([1]);
+      }, `Expected the value to be an array that starts with '[1]', but it was undefined`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.startWith(["Civic"]);
+          });
+        },
+        `Expected parent.cars to be an array that starts with '["Civic"]', but it was missing all of them`,
+        `parent.cars: '["Tesla","Civic"]'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.name).to.startWith("Bry");
+          });
+        },
+        `Expected parent.name to be a string that starts with "Bry", but it was missing`,
+        `parent.name: "Daymon"`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/start-with/index.ts
+++ b/src/expect/extensions/start-with/index.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Assertion } from "@rbxts/expect";
+import { startsWith } from "@rbxts/string-utils";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+import { getIndexOrNull, isArray } from "@src/util/object";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be `
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .nestedMetadata({ [place.path]: place.actual.value })
+  .negationSuffix(`, but it did`);
+
+function validateArrayStartsWith(
+  source: Assertion,
+  actual: unknown,
+  expected: defined[]
+) {
+  const message = baseMessage
+    .use(`an array that starts with ${place.expected.value}`)
+    .expectedValue(expected);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!(source.is_array ?? isArray(actual))) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't an array");
+  }
+
+  const missing = expected.filter(
+    (it, index) => getIndexOrNull(actual, index) !== it
+  );
+
+  if (missing.isEmpty()) return message.pass();
+
+  if (missing.size() === expected.size()) {
+    return message.failWithReason("was missing all of them");
+  } else if (missing.size() > 1) {
+    return message
+      .metadata({ Missing: message.encode(missing) })
+      .failWithReason(`was missing ${missing.size()} elements`);
+  } else {
+    return message.failWithReason(`was missing ${message.encode(missing[0])}`);
+  }
+}
+
+function validateStringStartsWith(actual: unknown, expected: string) {
+  const message = baseMessage
+    .use(`a string that starts with ${place.expected.value}`)
+    .expectedValue(expected);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "string")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a string");
+  }
+
+  return startsWith(actual, expected)
+    ? message.pass()
+    : message.failWithReason("was missing");
+}
+
+const startWith: CustomMethodImpl = (
+  source,
+  actual,
+  expected: string | defined[]
+) => {
+  if (typeIs(expected, "string")) {
+    return validateStringStartsWith(actual, expected);
+  } else {
+    return validateArrayStartsWith(source, actual, expected);
+  }
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the array starts with the specified elements.
+     *
+     * @param elements - Elements that the actual array should have at the start.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect([1,2,3]).to.startWith([1,2]);
+     * ```
+     *
+     * @public
+     */
+    startWith(elements: InferArrayElement<T>[]): this;
+
+    /**
+     * Asserts that the array starts with the specified elements.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.startWith | startWith}._
+     *
+     * @param elements - Elements that the actual array should have at the start.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect([1,2,3]).to.be.an.array().that.startsWith([1,2]);
+     * ```
+     *
+     * @public
+     */
+    startsWith(elements: InferArrayElement<T>[]): this;
+
+    /**
+     * Asserts that the actual value is a string that starts with
+     * the specified string.
+     *
+     * @param str - A string that should be at the start of the actual value.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.startWith("Day");
+     * ```
+     *
+     * @public
+     */
+    startWith(str: string): Assertion<string>;
+
+    /**
+     * Asserts that the actual value is a string that starts with
+     * the specified string.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.startWith | startWith}._
+     *
+     * @param str - A string that should be at the start of the actual value.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.be.a.string().that.startsWith("Day");
+     * ```
+     *
+     * @public
+     */
+    startsWith(str: string): Assertion<string>;
+  }
+}
+
+extendMethods({
+  startWith: startWith,
+  startsWith: startWith,
+});

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -39,3 +39,14 @@ export function mapObjectValues<T extends object>(
 export function isArray(element: unknown): element is defined[] {
   return t.array(t.any)(element);
 }
+
+/**
+ * @internal
+ */
+export function getIndexOrNull(element: unknown, index: number) {
+  try {
+    return (element as defined[])[index];
+  } catch (e) {
+    return undefined;
+  }
+}

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -1343,6 +1343,50 @@ Asserts that at least one element in the array satisfies the specified [Filter](
 </td></tr>
 <tr><td>
 
+[startsWith(elements)](./expect.assertion.startswith.md)
+
+
+</td><td>
+
+Asserts that the array starts with the specified elements.
+
+
+</td></tr>
+<tr><td>
+
+[startsWith(str)](./expect.assertion.startswith_1.md)
+
+
+</td><td>
+
+Asserts that the actual value is a string that starts with the specified string.
+
+
+</td></tr>
+<tr><td>
+
+[startWith(elements)](./expect.assertion.startwith.md)
+
+
+</td><td>
+
+Asserts that the array starts with the specified elements.
+
+
+</td></tr>
+<tr><td>
+
+[startWith(str)](./expect.assertion.startwith_1.md)
+
+
+</td><td>
+
+Asserts that the actual value is a string that starts with the specified string.
+
+
+</td></tr>
+<tr><td>
+
 [string()](./expect.assertion.string.md)
 
 

--- a/wiki/docs/api/expect.assertion.startswith.md
+++ b/wiki/docs/api/expect.assertion.startswith.md
@@ -1,0 +1,69 @@
+---
+id: expect.assertion.startswith
+title: Assertion.startsWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [startsWith](./expect.assertion.startswith.md)
+
+## Assertion.startsWith() method
+
+Asserts that the array starts with the specified elements.
+
+**Signature:**
+
+```typescript
+startsWith(elements: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+elements
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+Elements that the actual array should have at the start.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Remarks
+
+_Type alias for ._
+
+## Example
+
+
+```ts
+expect([1,2,3]).to.be.an.array().that.startsWith([1,2]);
+```

--- a/wiki/docs/api/expect.assertion.startswith_1.md
+++ b/wiki/docs/api/expect.assertion.startswith_1.md
@@ -1,0 +1,69 @@
+---
+id: expect.assertion.startswith_1
+title: Assertion.startsWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [startsWith](./expect.assertion.startswith_1.md)
+
+## Assertion.startsWith() method
+
+Asserts that the actual value is a string that starts with the specified string.
+
+**Signature:**
+
+```typescript
+startsWith(str: string): Assertion<string>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+str
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+A string that should be at the start of the actual value.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;string&gt;
+
+This instance for chaining.
+
+## Remarks
+
+_Type alias for ._
+
+## Example
+
+
+```ts
+expect("Daymon").to.be.a.string().that.startsWith("Day");
+```

--- a/wiki/docs/api/expect.assertion.startwith.md
+++ b/wiki/docs/api/expect.assertion.startwith.md
@@ -1,0 +1,65 @@
+---
+id: expect.assertion.startwith
+title: Assertion.startWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [startWith](./expect.assertion.startwith.md)
+
+## Assertion.startWith() method
+
+Asserts that the array starts with the specified elements.
+
+**Signature:**
+
+```typescript
+startWith(elements: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+elements
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+Elements that the actual array should have at the start.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Example
+
+
+```ts
+expect([1,2,3]).to.startWith([1,2]);
+```

--- a/wiki/docs/api/expect.assertion.startwith_1.md
+++ b/wiki/docs/api/expect.assertion.startwith_1.md
@@ -1,0 +1,65 @@
+---
+id: expect.assertion.startwith_1
+title: Assertion.startWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [startWith](./expect.assertion.startwith_1.md)
+
+## Assertion.startWith() method
+
+Asserts that the actual value is a string that starts with the specified string.
+
+**Signature:**
+
+```typescript
+startWith(str: string): Assertion<string>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+str
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+A string that should be at the start of the actual value.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;string&gt;
+
+This instance for chaining.
+
+## Example
+
+
+```ts
+expect("Daymon").to.startWith("Day");
+```

--- a/wiki/docs/matchers/arrays.mdx
+++ b/wiki/docs/matchers/arrays.mdx
@@ -131,11 +131,22 @@ Extra Elements: '[2]'
 
 ### Starts with
 
-:::info
+You can use the [startsWith](/docs/api/expect.assertion.startWith.md) method to check if an array starts with another
+array.
 
-[GitHub Issue #3](https://github.com/daymxn/rbxts-expect/issues/3)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect([1, 2, 3]).to.startWith([1, 2]);
+```
+
+#### Example error
+
+```logs
+Expected '[1,2,3]' to be an array that starts with '[1,4,5]', but it was missing 2 elements
+
+Missing: '[4,5]'
+```
 
 ### Ends with
 

--- a/wiki/docs/matchers/strings.mdx
+++ b/wiki/docs/matchers/strings.mdx
@@ -75,11 +75,20 @@ Expected "12345" to have a size of exactly '6', but it actually had a size of '5
 
 ### Starts with
 
-:::info
+You can use the [startsWith](/docs/api/expect.assertion.startWith.md) method to check if a string starts with another
+string.
 
-[GitHub Issue #3](https://github.com/daymxn/rbxts-expect/issues/3)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect("daymon").to.startWith("day");
+```
+
+#### Example error
+
+```logs
+Expected "day" to be a string that starts with "bry", but it was missing
+```
 
 ### Ends with
 


### PR DESCRIPTION
Adds the `startWith` and `startsWith` matchers to check if an array or string starts with another.

This PR also includes a fix for the `length` matcher where it wasn't properly validating empty arrays/objects.

Fixes #3 