### PR TITLE
Add the `endsWith` matcher

### DIFF
--- a/.changeset/cold-pants-tie.md
+++ b/.changeset/cold-pants-tie.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `endWith` and `endsWith` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -47,6 +47,10 @@ export interface Assertion<T = unknown> {
     defined(): this;
     readonly does: this;
     empty(): Assertion<T>;
+    endsWith(elements: InferArrayElement<T>[]): this;
+    endsWith(str: string): Assertion<string>;
+    endWith(elements: InferArrayElement<T>[]): this;
+    endWith(str: string): Assertion<string>;
     enum<R>(enumType: R & Record<number, string>): Assertion<EnumValue<R>>;
     enum<R>(enumType: R & Record<number, string>, value: R[keyof R]): Assertion<EnumValue<R>>;
     enum<R>(enumType: R & Record<number, string>, value: keyof R): Assertion<EnumValue<R>>;

--- a/src/expect/extensions/end-with/index.spec.ts
+++ b/src/expect/extensions/end-with/index.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("endWith", () => {
+    it("checks if arrays end with the given elements", () => {
+      expect([1, 2, 3]).to.endWith([2, 3]).but.not.endWith([1, 2]);
+    });
+
+    it("checks if strings end with the given characters ", () => {
+      expect("12345").to.endWith("345").but.not.endWith("123");
+    });
+
+    it("works with empty values", () => {
+      expect([]).to.endWith([]);
+      expect("").to.endWith("");
+    });
+  });
+
+  describe("error message", () => {
+    it("throws if the array doesn't have all of the elements", () => {
+      err(() => {
+        expect([1, 2]).to.endWith([2, 3]);
+      }, `Expected '[1,2]' to be an array that ends with '[2,3]', but it was missing all of them`);
+    });
+
+    it("throws if the string doesn't have all of the elements", () => {
+      err(() => {
+        expect("day").to.endWith("mon");
+      }, `Expected "day" to be a string that ends with "mon", but it was missing`);
+    });
+
+    it("throws if the string doesn't have some of the elements", () => {
+      err(() => {
+        expect("day").to.endWith("dy");
+      }, `Expected "day" to be a string that ends with "dy", but it was missing`);
+    });
+
+    it("throws if the array is missing one of the elements", () => {
+      err(() => {
+        expect([1, 2]).to.endWith([0, 2]);
+      }, `Expected '[1,2]' to be an array that ends with '[0,2]', but it was missing '0'`);
+    });
+
+    it("throws if the array is missing multiple elements", () => {
+      err(
+        () => {
+          expect([1, 2, 3, 4]).to.endWith([1, 2, 4]);
+        },
+        `Expected '[1,2,3,4]' to be an array that ends with '[1,2,4]', but it was missing 2 elements`,
+        `Missing: '[1,2]'`
+      );
+    });
+
+    it("throws if the type isn't a string", () => {
+      err(() => {
+        expect([1, 2]).to.endWith("day");
+      }, `Expected '[1,2]' (table) to be a string that ends with "day", but it wasn't a string`);
+    });
+
+    it("throws if the type isn't an array", () => {
+      err(() => {
+        expect("day" as never as number[]).to.endWith([1]);
+      }, `Expected "day" (string) to be an array that ends with '[1]', but it wasn't an array`);
+    });
+
+    it("throws if the type is undefined", () => {
+      err(() => {
+        expect(undefined).to.endWith("day");
+      }, `Expected the value to be a string that ends with "day", but it was undefined`);
+
+      err(() => {
+        expect(undefined as never as number[]).to.endWith([1]);
+      }, `Expected the value to be an array that ends with '[1]', but it was undefined`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.endWith(["Tesla"]);
+          });
+        },
+        `Expected parent.cars to be an array that ends with '["Tesla"]', but it was missing all of them`,
+        `parent.cars: '["Tesla","Civic"]'`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.name).to.endWith("yle");
+          });
+        },
+        `Expected parent.name to be a string that ends with "yle", but it was missing`,
+        `parent.name: "Daymon"`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/end-with/index.ts
+++ b/src/expect/extensions/end-with/index.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Assertion } from "@rbxts/expect";
+import { reverseArray } from "@rbxts/reverse-array";
+import { endsWith } from "@rbxts/string-utils";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+import { getIndexOrNull, isArray } from "@src/util/object";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be `
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .nestedMetadata({ [place.path]: place.actual.value })
+  .negationSuffix(`, but it did`);
+
+function validateArrayEndsWith(
+  source: Assertion,
+  actual: unknown,
+  expected: defined[]
+) {
+  const message = baseMessage
+    .use(`an array that ends with ${place.expected.value}`)
+    .expectedValue(expected);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!(source.is_array ?? isArray(actual))) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't an array");
+  }
+
+  const missing = reverseArray(expected).filter((it, index) => {
+    const offset = (actual as defined[]).size() - index - 1;
+    return getIndexOrNull(actual, offset) !== it;
+  });
+
+  if (missing.isEmpty()) return message.pass();
+
+  if (missing.size() === expected.size()) {
+    return message.failWithReason("was missing all of them");
+  } else if (missing.size() > 1) {
+    return message
+      .metadata({ Missing: message.encode(reverseArray(missing)) })
+      .failWithReason(`was missing ${missing.size()} elements`);
+  } else {
+    return message.failWithReason(`was missing ${message.encode(missing[0])}`);
+  }
+}
+
+function validateStringEndsWith(actual: unknown, expected: string) {
+  const message = baseMessage
+    .use(`a string that ends with ${place.expected.value}`)
+    .expectedValue(expected);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "string")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a string");
+  }
+
+  return endsWith(actual, expected)
+    ? message.pass()
+    : message.failWithReason("was missing");
+}
+
+const endWith: CustomMethodImpl = (
+  source,
+  actual,
+  expected: string | defined[]
+) => {
+  if (typeIs(expected, "string")) {
+    return validateStringEndsWith(actual, expected);
+  } else {
+    return validateArrayEndsWith(source, actual, expected);
+  }
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the array ends with the specified elements.
+     *
+     * @param elements - Elements that the actual array should have at the ends.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect([1,2,3]).to.endWith([2,3]);
+     * ```
+     *
+     * @public
+     */
+    endWith(elements: InferArrayElement<T>[]): this;
+
+    /**
+     * Asserts that the array ends with the specified elements.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.endWith | endWith}._
+     *
+     * @param elements - Elements that the actual array should have at the ends.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect([1,2,3]).to.be.an.array().that.endWith([2,3]);
+     * ```
+     *
+     * @public
+     */
+    endsWith(elements: InferArrayElement<T>[]): this;
+
+    /**
+     * Asserts that the actual value is a string that ends with
+     * the specified string.
+     *
+     * @param str - A string that should be at the end of the actual value.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.endWith("mon");
+     * ```
+     *
+     * @public
+     */
+    endWith(str: string): Assertion<string>;
+
+    /**
+     * Asserts that the actual value is a string that ends with
+     * the specified string.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.endWith | endWith}._
+     *
+     * @param str - A string that should be at the end of the actual value.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect("Daymon").to.be.a.string().that.endsWith("mon");
+     * ```
+     *
+     * @public
+     */
+    endsWith(str: string): Assertion<string>;
+  }
+}
+
+extendMethods({
+  endWith: endWith,
+  endsWith: endWith,
+});

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -23,6 +23,7 @@ import "./contain-exactly-in-order";
 import "./deep-equal";
 import "./defined";
 import "./empty";
+import "./end-with";
 import "./enum";
 import "./even-odd";
 import "./include";

--- a/wiki/docs/api/expect.assertion.endswith.md
+++ b/wiki/docs/api/expect.assertion.endswith.md
@@ -1,0 +1,69 @@
+---
+id: expect.assertion.endswith
+title: Assertion.endsWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [endsWith](./expect.assertion.endswith.md)
+
+## Assertion.endsWith() method
+
+Asserts that the array ends with the specified elements.
+
+**Signature:**
+
+```typescript
+endsWith(elements: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+elements
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+Elements that the actual array should have at the ends.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Remarks
+
+_Type alias for ._
+
+## Example
+
+
+```ts
+expect([1,2,3]).to.be.an.array().that.endWith([2,3]);
+```

--- a/wiki/docs/api/expect.assertion.endswith_1.md
+++ b/wiki/docs/api/expect.assertion.endswith_1.md
@@ -1,0 +1,69 @@
+---
+id: expect.assertion.endswith_1
+title: Assertion.endsWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [endsWith](./expect.assertion.endswith_1.md)
+
+## Assertion.endsWith() method
+
+Asserts that the actual value is a string that ends with the specified string.
+
+**Signature:**
+
+```typescript
+endsWith(str: string): Assertion<string>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+str
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+A string that should be at the end of the actual value.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;string&gt;
+
+This instance for chaining.
+
+## Remarks
+
+_Type alias for ._
+
+## Example
+
+
+```ts
+expect("Daymon").to.be.a.string().that.endsWith("mon");
+```

--- a/wiki/docs/api/expect.assertion.endwith.md
+++ b/wiki/docs/api/expect.assertion.endwith.md
@@ -1,0 +1,65 @@
+---
+id: expect.assertion.endwith
+title: Assertion.endWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [endWith](./expect.assertion.endwith.md)
+
+## Assertion.endWith() method
+
+Asserts that the array ends with the specified elements.
+
+**Signature:**
+
+```typescript
+endWith(elements: InferArrayElement<T>[]): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+elements
+
+
+</td><td>
+
+[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;\[\]
+
+
+</td><td>
+
+Elements that the actual array should have at the ends.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Example
+
+
+```ts
+expect([1,2,3]).to.endWith([2,3]);
+```

--- a/wiki/docs/api/expect.assertion.endwith_1.md
+++ b/wiki/docs/api/expect.assertion.endwith_1.md
@@ -1,0 +1,65 @@
+---
+id: expect.assertion.endwith_1
+title: Assertion.endWith() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [endWith](./expect.assertion.endwith_1.md)
+
+## Assertion.endWith() method
+
+Asserts that the actual value is a string that ends with the specified string.
+
+**Signature:**
+
+```typescript
+endWith(str: string): Assertion<string>;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+str
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+A string that should be at the end of the actual value.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;string&gt;
+
+This instance for chaining.
+
+## Example
+
+
+```ts
+expect("Daymon").to.endWith("mon");
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -804,6 +804,50 @@ Asserts that the value is empty.
 </td></tr>
 <tr><td>
 
+[endsWith(elements)](./expect.assertion.endswith.md)
+
+
+</td><td>
+
+Asserts that the array ends with the specified elements.
+
+
+</td></tr>
+<tr><td>
+
+[endsWith(str)](./expect.assertion.endswith_1.md)
+
+
+</td><td>
+
+Asserts that the actual value is a string that ends with the specified string.
+
+
+</td></tr>
+<tr><td>
+
+[endWith(elements)](./expect.assertion.endwith.md)
+
+
+</td><td>
+
+Asserts that the array ends with the specified elements.
+
+
+</td></tr>
+<tr><td>
+
+[endWith(str)](./expect.assertion.endwith_1.md)
+
+
+</td><td>
+
+Asserts that the actual value is a string that ends with the specified string.
+
+
+</td></tr>
+<tr><td>
+
 [enum(enumType)](./expect.assertion.enum.md)
 
 

--- a/wiki/docs/matchers/arrays.mdx
+++ b/wiki/docs/matchers/arrays.mdx
@@ -150,11 +150,21 @@ Missing: '[4,5]'
 
 ### Ends with
 
-:::info
+You can use the [endsWith](/docs/api/expect.assertion.endWith.md) method to check if an array ends with another array.
 
-[GitHub Issue #4](https://github.com/daymxn/rbxts-expect/issues/4)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect([1, 2, 3]).to.endWith([2, 3]);
+```
+
+#### Example error
+
+```logs
+Expected '[1,2,3,4]' to be an array that ends with '[1,2,4]', but it was missing 2 elements
+
+Missing: '[1,2]'
+```
 
 ### All of
 

--- a/wiki/docs/matchers/strings.mdx
+++ b/wiki/docs/matchers/strings.mdx
@@ -92,11 +92,19 @@ Expected "day" to be a string that starts with "bry", but it was missing
 
 ### Ends with
 
-:::info
+You can use the [endsWith](/docs/api/expect.assertion.endWith.md) method to check if a string ends with another string.
 
-[GitHub Issue #4](https://github.com/daymxn/rbxts-expect/issues/4)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect("daymon").to.endWith("mon");
+```
+
+#### Example error
+
+```logs
+Expected "daymon" to be a string that ends with "yan", but it was missing
+```
 
 ### All of
 


### PR DESCRIPTION
Adds the `endsWith` and `endWith` matchers to check if an array or string ends with another.

Fixes #4 