### PR TITLE
Add `true` and `false` matchers

### DIFF
--- a/.changeset/orange-jobs-greet.md
+++ b/.changeset/orange-jobs-greet.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `true`, `false`, `truthy` and `falsy` matchers

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -62,6 +62,8 @@ export interface Assertion<T = unknown> {
     even(): Assertion<number>;
     exist(): this;
     exists(): this;
+    false(): this;
+    falsy(): this;
     function(): Assertion<object>;
     greaterThan(value: number): Assertion<number>;
     greaterThanOrEqualTo(value: number): Assertion<number>;
@@ -131,6 +133,8 @@ export interface Assertion<T = unknown> {
     throws(substring: string): Assertion<T>;
     throwsMatch(pattern: string): Assertion<T>;
     readonly to: this;
+    true(): this;
+    truthy(): this;
     typeOf<I extends keyof CheckableTypes>(name: I): Assertion<I>;
     typeOf<I>(checker: TypeCheckCallback<T>): Assertion<I>;
     typeOf<I>(tChecker: t.check<I>): Assertion<I>;

--- a/src/expect/extensions/true-false/index.spec.ts
+++ b/src/expect/extensions/true-false/index.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("true", () => {
+    it("checks that the value is the boolean true", () => {
+      expect(true).to.be.true();
+      expect(false).to.not.be.true();
+
+      expect(1).to.not.be.true();
+    });
+  });
+
+  describe("false", () => {
+    it("checks that the value is the boolean false", () => {
+      expect(false).to.be.false();
+      expect(true).to.not.be.false();
+
+      expect(0).to.not.be.false();
+    });
+  });
+
+  describe("truthy", () => {
+    it("checks that the value is truthy according to luau", () => {
+      expect(true).to.be.truthy();
+      expect(false).to.not.be.truthy();
+
+      expect(0).to.be.truthy();
+      expect("").to.be.truthy();
+    });
+  });
+
+  describe("falsy", () => {
+    it("checks that the value is falsy according to luau", () => {
+      expect(false).to.be.falsy();
+      expect(true).to.not.be.falsy();
+
+      expect(undefined).to.be.falsy();
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the value is not the expected boolean", () => {
+      err(() => {
+        expect(true).to.be.false();
+      }, `Expected 'true' to be 'false'`);
+
+      err(() => {
+        expect(false).to.be.true();
+      }, `Expected 'false' to be 'true'`);
+    });
+
+    it("throws when the value is not truthy or falsy", () => {
+      err(() => {
+        expect(100).to.be.falsy();
+      }, `Expected '100' to be falsy, but it was not`);
+
+      err(() => {
+        expect(false).to.be.truthy();
+      }, `Expected 'false' to be truthy, but it was not`);
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.be.true();
+      }, `Expected the value to be 'true', but it was undefined`);
+
+      err(() => {
+        expect(undefined).to.be.false();
+      }, `Expected the value to be 'false', but it was undefined`);
+
+      err(() => {
+        expect(undefined).to.be.truthy();
+      }, `Expected the value to be truthy, but it was undefined`);
+    });
+
+    it("throws when it's not a boolean", () => {
+      err(() => {
+        expect(5).to.have.be.true();
+      }, `Expected '5' (number) to be 'true', but it wasn't a boolean`);
+
+      err(() => {
+        expect(5).to.have.be.false();
+      }, `Expected '5' (number) to be 'false', but it wasn't a boolean`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.name).to.be.true();
+          });
+        },
+        `Expected parent.name to be 'true', but it wasn't a boolean`,
+        'parent.name: "Daymon"'
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.name).to.be.false();
+          });
+        },
+        `Expected parent.name to be 'false', but it wasn't a boolean`,
+        'parent.name: "Daymon"'
+      );
+
+      err(() => {
+        withProxy(TEST_SON, (son) => {
+          expect(son.parent?.parent).to.be.truthy();
+        });
+      }, `Expected parent.parent to be truthy, but it was undefined`);
+
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.name).to.be.falsy();
+          });
+        },
+        `Expected parent.name to be falsy, but it was not`,
+        'parent.name: "Daymon"'
+      );
+    });
+  });
+};

--- a/src/expect/extensions/true-false/index.ts
+++ b/src/expect/extensions/true-false/index.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+import { isLuauTruthy } from "@src/util/roblox";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be `
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .negationSuffix(", but it was")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+function validateIsBoolean(
+  message: ExpectMessageBuilder,
+  actual: unknown,
+  expected: boolean
+) {
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "boolean")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a boolean");
+  }
+
+  if (expected) {
+    return actual ? message.pass() : message.trailingFailureSuffix().fail();
+  } else {
+    return actual ? message.trailingFailureSuffix().fail() : message.pass();
+  }
+}
+
+const isTrue: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`'true'`);
+
+  return validateIsBoolean(message, actual, true);
+};
+
+const isFalse: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`'false'`);
+
+  return validateIsBoolean(message, actual, false);
+};
+
+const isTruthy: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`truthy`);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  return isLuauTruthy(actual)
+    ? message.pass()
+    : message.failWithReason("was not");
+};
+
+const isFalsy: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use(`falsy`);
+
+  return isLuauTruthy(actual)
+    ? message.failWithReason("was not")
+    : message.pass();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the value is a boolean of `true`.
+     *
+     * @example
+     * ```ts
+     * expect(true).to.be.true();
+     * ```
+     *
+     * @see {@link Assertion.false | false},
+     * {@link Assertion.truthy | truthy}
+     *
+     * @public
+     */
+    true(): this;
+
+    /**
+     * Asserts that the value is a boolean of `false`.
+     *
+     * @example
+     * ```ts
+     * expect(false).to.be.false();
+     * ```
+     *
+     * @see {@link Assertion.true | true},
+     * {@link Assertion.falsy | falsy}
+     *
+     * @public
+     */
+    false(): this;
+
+    /**
+     * Asserts that the value is a "truthy" value, according to luau.
+     *
+     * @remarks
+     * A truthy value is any value that isn't `false` or `nil`.
+     *
+     * You can read more about it on the
+     * [luau docs](https://create.roblox.com/docs/luau/booleans#conditionals).
+     *
+     * @example
+     * ```ts
+     * expect(1).to.be.truthy();
+     * expect(0).to.be.truthy();
+     *
+     * expect("day").to.be.truthy();
+     * expect("").to.be.truthy();
+     * ```
+     *
+     * @see {@link Assertion.falsy | falsy},
+     * {@link Assertion.true | true}
+     *
+     * @public
+     */
+    truthy(): this;
+
+    /**
+     * Asserts that the value is a "falsy" value, according to luau.
+     *
+     * @remarks
+     * A falsy value is a value of `false` or `nil`.
+     *
+     * You can read more about it on the
+     * [luau docs](https://create.roblox.com/docs/luau/booleans#conditionals).
+     *
+     * @example
+     * ```ts
+     * expect(false).to.be.falsy();
+     * expect(undefined).to.be.falsy();
+     *
+     * expect(0).to.not.be.falsy();
+     * expect("").to.not.be.falsy();
+     * ```
+     *
+     * @see {@link Assertion.truthy | truthy},
+     * {@link Assertion.false | false}
+     *
+     * @public
+     */
+    falsy(): this;
+  }
+}
+
+extendMethods({
+  true: isTrue,
+  false: isFalse,
+  truthy: isTruthy,
+  falsy: isFalsy,
+});

--- a/src/util/roblox.ts
+++ b/src/util/roblox.ts
@@ -15,30 +15,15 @@
  * limitations under the License.
  */
 
-import "./any-of";
-import "./array";
-import "./between";
-import "./contain-exactly";
-import "./contain-exactly-in-order";
-import "./deep-equal";
-import "./defined";
-import "./empty";
-import "./end-with";
-import "./enum";
-import "./even-odd";
-import "./include";
-import "./instance-of";
-import "./length";
-import "./match";
-import "./near";
-import "./negations";
-import "./noops";
-import "./number-comparators";
-import "./pattern";
-import "./positive-negative";
-import "./shallow-equal";
-import "./some";
-import "./start-with";
-import "./substring";
-import "./throws";
-import "./true-false";
+/**
+ * Newer versions of roblox-ts automatically transpile if conditions
+ * to ts-like truthy checks.
+ *
+ * Instead, this function performs a
+ * [luau truthy check](https://create.roblox.com/docs/luau/booleans#conditionals).
+ *
+ * @internal
+ */
+export function isLuauTruthy(value: unknown) {
+  return value !== false && value !== undefined;
+}

--- a/wiki/docs/api/expect.assertion.false.md
+++ b/wiki/docs/api/expect.assertion.false.md
@@ -1,0 +1,27 @@
+---
+id: expect.assertion.false
+title: Assertion.false() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [false](./expect.assertion.false.md)
+
+## Assertion.false() method
+
+Asserts that the value is a boolean of `false`<!-- -->.
+
+**Signature:**
+
+```typescript
+false(): this;
+```
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect(false).to.be.false();
+```

--- a/wiki/docs/api/expect.assertion.falsy.md
+++ b/wiki/docs/api/expect.assertion.falsy.md
@@ -1,0 +1,37 @@
+---
+id: expect.assertion.falsy
+title: Assertion.falsy() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [falsy](./expect.assertion.falsy.md)
+
+## Assertion.falsy() method
+
+Asserts that the value is a "falsy" value, according to luau.
+
+**Signature:**
+
+```typescript
+falsy(): this;
+```
+**Returns:**
+
+this
+
+## Remarks
+
+A falsy value is a value of `false` or `nil`<!-- -->.
+
+You can read more about it on the [luau docs](https://create.roblox.com/docs/luau/booleans#conditionals).
+
+## Example
+
+
+```ts
+expect(false).to.be.falsy();
+expect(undefined).to.be.falsy();
+
+expect(0).to.not.be.falsy();
+expect("").to.not.be.falsy();
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -958,6 +958,28 @@ Asserts that the actual value is a non `null` value.
 </td></tr>
 <tr><td>
 
+[false()](./expect.assertion.false.md)
+
+
+</td><td>
+
+Asserts that the value is a boolean of `false`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[falsy()](./expect.assertion.falsy.md)
+
+
+</td><td>
+
+Asserts that the value is a "falsy" value, according to luau.
+
+
+</td></tr>
+<tr><td>
+
 [function()](./expect.assertion.function.md)
 
 
@@ -1525,6 +1547,28 @@ Asserts that the function throws an exception that contains the string `substrin
 </td><td>
 
 Asserts that the function throws an exception that matches the lua pattern `pattern`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[true()](./expect.assertion.true.md)
+
+
+</td><td>
+
+Asserts that the value is a boolean of `true`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[truthy()](./expect.assertion.truthy.md)
+
+
+</td><td>
+
+Asserts that the value is a "truthy" value, according to luau.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.true.md
+++ b/wiki/docs/api/expect.assertion.true.md
@@ -1,0 +1,27 @@
+---
+id: expect.assertion.true
+title: Assertion.true() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [true](./expect.assertion.true.md)
+
+## Assertion.true() method
+
+Asserts that the value is a boolean of `true`<!-- -->.
+
+**Signature:**
+
+```typescript
+true(): this;
+```
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect(true).to.be.true();
+```

--- a/wiki/docs/api/expect.assertion.truthy.md
+++ b/wiki/docs/api/expect.assertion.truthy.md
@@ -1,0 +1,37 @@
+---
+id: expect.assertion.truthy
+title: Assertion.truthy() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [truthy](./expect.assertion.truthy.md)
+
+## Assertion.truthy() method
+
+Asserts that the value is a "truthy" value, according to luau.
+
+**Signature:**
+
+```typescript
+truthy(): this;
+```
+**Returns:**
+
+this
+
+## Remarks
+
+A truthy value is any value that isn't `false` or `nil`<!-- -->.
+
+You can read more about it on the [luau docs](https://create.roblox.com/docs/luau/booleans#conditionals).
+
+## Example
+
+
+```ts
+expect(1).to.be.truthy();
+expect(0).to.be.truthy();
+
+expect("day").to.be.truthy();
+expect("").to.be.truthy();
+```

--- a/wiki/docs/matchers/arrays.mdx
+++ b/wiki/docs/matchers/arrays.mdx
@@ -131,7 +131,7 @@ Extra Elements: '[2]'
 
 ### Starts with
 
-You can use the [startsWith](/docs/api/expect.assertion.startWith.md) method to check if an array starts with another
+You can use the [startsWith](/docs/api/expect.assertion.startwith.md) method to check if an array starts with another
 array.
 
 ```ts
@@ -150,7 +150,7 @@ Missing: '[4,5]'
 
 ### Ends with
 
-You can use the [endsWith](/docs/api/expect.assertion.endWith.md) method to check if an array ends with another array.
+You can use the [endsWith](/docs/api/expect.assertion.endwith.md) method to check if an array ends with another array.
 
 ```ts
 import { expect } from "@rbxts/expect";

--- a/wiki/docs/matchers/strings.mdx
+++ b/wiki/docs/matchers/strings.mdx
@@ -75,7 +75,7 @@ Expected "12345" to have a size of exactly '6', but it actually had a size of '5
 
 ### Starts with
 
-You can use the [startsWith](/docs/api/expect.assertion.startWith.md) method to check if a string starts with another
+You can use the [startsWith](/docs/api/expect.assertion.startwith_1.md) method to check if a string starts with another
 string.
 
 ```ts
@@ -92,7 +92,8 @@ Expected "day" to be a string that starts with "bry", but it was missing
 
 ### Ends with
 
-You can use the [endsWith](/docs/api/expect.assertion.endWith.md) method to check if a string ends with another string.
+You can use the [endsWith](/docs/api/expect.assertion.endwith_1.md) method to check if a string ends with another
+string.
 
 ```ts
 import { expect } from "@rbxts/expect";

--- a/wiki/docs/quick-start.mdx
+++ b/wiki/docs/quick-start.mdx
@@ -127,7 +127,7 @@ Expected 'Basketball' (enum/number) to be any of '["Soccer", "Football"]'
 :::tip
 
 You can also use [equal](/docs/api/expect.assertion.equal.md), since it points to
-[deepEqual](/docs/api/expect.assertion.deepEqual.md) by default!
+[deepEqual](/docs/api/expect.assertion.deepequal.md) by default!
 
 :::
 

--- a/wiki/src/components/table.tsx
+++ b/wiki/src/components/table.tsx
@@ -29,12 +29,6 @@ const Table: React.FC = () => {
       </thead>
       <tbody>
         <Entry
-          old={`expect(5).to.be.near(5 + 1e-8)`}
-          new={`expect(5).to.be.closeTo(5 + 1e-8)`}
-        >
-          Will be supported with issue <a href="https://github.com/daymxn/rbxts-expect/issues/6">#6</a>
-        </Entry>
-        <Entry
           old={`expect(5).to.be.a("number")`}
           new={`expect(5).to.be.a.number()`}
         >


### PR DESCRIPTION
Adds the `true` and `false` matchers to check if a value is a boolean of `true` or `false` respectively.

Also adds the `truthy` and `falsy` matchers to check if a value is a "truthy" according to luau.

And finally, includes a fix for some links in the wiki + removes an old mapping (now that we've added `near`).

Fixes #11 