### PR TITLE
Prepare for 2.0 release

### DIFF
--- a/.changeset/afraid-penguins-yawn.md
+++ b/.changeset/afraid-penguins-yawn.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `finite` matcher

--- a/.changeset/great-boats-applaud.md
+++ b/.changeset/great-boats-applaud.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for supplying custom message overrides by providing a second argument to `expect`

--- a/.changeset/green-buttons-relax.md
+++ b/.changeset/green-buttons-relax.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `key` and `property` matchers

--- a/.changeset/serious-dolphins-move.md
+++ b/.changeset/serious-dolphins-move.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `satisfy` and `satisfies` matchers

--- a/.changeset/silver-goats-bake.md
+++ b/.changeset/silver-goats-bake.md
@@ -1,0 +1,5 @@
+---
+"@rbxts/expect": minor
+---
+
+Added support for the `all` matcher

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ remotes.purchasePet.connect(async (player, petId) => {
   const data = saves.get(player);
   const pet = pets.get(petId);
 
-  expect(data.money).to.be.gte(pet.cost);
+  expect(data.money, "You don't have enough money!").to.be.gte(pet.cost);
 
   data.money -= pet.cost;
   data.pets.push(pet);

--- a/README.md
+++ b/README.md
@@ -229,11 +229,11 @@ You can either checkout our [Quick Start](https://rbxts-expect.daymxn.com/docs/q
 
 ## Roadmap
 
-- Add publishing for wally
-- Add docs for lua usage
-- Implement workflow for test coverage
-- Add workflow for checking API diff and version bumping according to semver
-- Add note in contributing about checking the api diff
+* Add publishing for wally
+* Add docs for lua usage
+* Implement workflow for test coverage
+* Add workflow for checking API diff and version bumping according to semver
+* Add note in contributing about checking the api diff
 
 ## Contributing
 

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -64,6 +64,7 @@ export interface Assertion<T = unknown> {
     exists(): this;
     false(): this;
     falsy(): this;
+    finite(): Assertion<number>;
     function(): Assertion<object>;
     greaterThan(value: number): Assertion<number>;
     greaterThanOrEqualTo(value: number): Assertion<number>;

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -108,6 +108,8 @@ export interface Assertion<T = unknown> {
     positive(): Assertion<number>;
     // @internal (undocumented)
     _proxy?: Proxy<T>;
+    satisfies(filter: Filter<T>): this;
+    satisfy(filter: Filter<T>): this;
     // @internal (undocumented)
     _self: this;
     shallowEqual<R = T>(expectedValue: R): Assertion<R>;

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -170,7 +170,7 @@ export type EnumValue<E> = E[keyof E];
 export function err(callback: () => unknown, ...messages: string[]): void;
 
 // @public
-export function expect<T>(value: T): Assertion<T>;
+export function expect<T>(value: T, customMessage?: string): Assertion<T>;
 
 // @public
 export interface ExpectConfig {

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -78,6 +78,7 @@ export interface Assertion<T = unknown> {
     instanceOf<I>(tChecker: t.check<I>): Assertion<I>;
     readonly is: this;
     is_array?: boolean;
+    key(key: string): this;
     least(value: number): Assertion<number>;
     length(size: number): this;
     lengthOf(size: number): this;
@@ -107,6 +108,7 @@ export interface Assertion<T = unknown> {
     readonly or: this;
     pattern(pattern: string): this;
     positive(): Assertion<number>;
+    property(property: string): this;
     // @internal (undocumented)
     _proxy?: Proxy<T>;
     satisfies(filter: Filter<T>): this;

--- a/api/expect.api.md
+++ b/api/expect.api.md
@@ -18,6 +18,8 @@ export interface ActualPlaceholder {
 export interface Assertion<T = unknown> {
     readonly a: this;
     above(value: number): Assertion<number>;
+    all(condition: Filter<InferArrayElement<T>>): this;
+    all(reason: string, condition: Filter<InferArrayElement<T>>): this;
     readonly also: this;
     readonly an: this;
     readonly and: this;

--- a/src/expect/extensions/all/index.spec.ts
+++ b/src/expect/extensions/all/index.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { startsWith } from "@rbxts/string-utils";
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("all", () => {
+    it("checks if all the array elements pass", () => {
+      expect([1, 2, 3])
+        .to.all((it) => typeIs(it, "number"))
+        .but.not.all((it) => it % 2 === 0);
+
+      expect([1, 2, 3])
+        .to.all("be numbers", (it) => typeIs(it, "number"))
+        .but.not.all("be even", (it) => it % 2 === 0);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws if the check fails", () => {
+      err(
+        () => {
+          expect([1, 2]).to.all((it) => it === 1);
+        },
+        `Expected '[1,2]' to all pass some check, but there was an element that failed the check`,
+        "Index: 2",
+        "Value: '2"
+      );
+
+      err(() => {
+        expect([1, 1]).to.not.all((it) => it === 1);
+      }, `Expected '[1,1]' to NOT all pass some check, but they did`);
+    });
+
+    it("throws if the check fails, with the provided reason", () => {
+      err(
+        () => {
+          expect([1, 2]).to.all("equal 1", (it) => it === 1);
+        },
+        `Expected '[1,2]' to all equal 1, but there was an element that failed the check`,
+        "Index: 2",
+        "Value: '2"
+      );
+
+      err(() => {
+        expect([1, 1]).to.not.all("equal 1", (it) => it === 1);
+      }, `Expected '[1,1]' to NOT all equal 1, but they did`);
+    });
+
+    it("throws if the value is undefined", () => {
+      err(() => {
+        expect(undefined as unknown as unknown[]).to.all(() => true);
+      }, `Expected the values to all pass some check, but it was undefined`);
+
+      err(() => {
+        expect(undefined as unknown as unknown[]).to.all(
+          "like pizza",
+          () => true
+        );
+      }, `Expected the values to all like pizza, but it was undefined`);
+    });
+
+    it("throws if the value is not an array", () => {
+      err(() => {
+        expect(5 as unknown as unknown[]).to.all(() => true);
+      }, `Expected '5' to all pass some check, but it wasn't an array`);
+
+      err(() => {
+        expect(5 as unknown as unknown[]).to.all("like pizza", () => true);
+      }, `Expected '5' to all like pizza, but it wasn't an array`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.all(() => false);
+          });
+        },
+        "Expected parent.cars to all pass some check, but there was an element that failed the check",
+        `parent.cars: '["Tesla","Civic"]'`,
+        "Index: 1",
+        `Value: "Tesla"`
+      );
+
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.cars).to.all(`start with "Civ"`, (it) =>
+              startsWith(it, "Civ")
+            );
+          });
+        },
+        `Expected parent.cars to all start with "Civ", but there was an element that failed the check`,
+        `parent.cars: '["Tesla","Civic"]'`,
+        "Index: 1",
+        `Value: "Tesla"`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/all/index.ts
+++ b/src/expect/extensions/all/index.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable roblox-ts/no-array-pairs */
+
+import type { Filter } from "@rbxts/expect";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+import { isArray } from "@src/util/object";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} all ${place.reason}`
+)
+  .negationSuffix(`, but they did`)
+  .reason("pass some check")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+const all: CustomMethodImpl<unknown[]> = (
+  source,
+  actual,
+  reasonOrCallback: string | Filter,
+  maybeCallback?: Filter
+) => {
+  const message = baseMessage.use();
+
+  if (typeIs(reasonOrCallback, "string")) {
+    message.reason(reasonOrCallback);
+  }
+
+  if (actual === undefined) {
+    return message
+      .name("the values")
+      .trailingFailureSuffix(", but it was undefined")
+      .fail();
+  }
+
+  const actualIsArray = source.is_array ?? isArray(actual);
+  if (!actualIsArray)
+    return message.trailingFailurePrefix(", but it wasn't an array").fail();
+
+  const callback = (maybeCallback ?? reasonOrCallback) as Filter;
+
+  for (const [Index, value] of ipairs(actual)) {
+    const result = callback(value as never);
+
+    if (!result) {
+      return message
+        .trailingFailureSuffix(
+          ", but there was an element that failed the check"
+        )
+        .metadata({
+          Index,
+          Value: message.encode(value),
+        })
+        .fail();
+    }
+  }
+
+  return message.pass();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that all elements in the array satisfy the specified {@link Filter}.
+     *
+     * @param condition - A callback that returns `true` whenever the condition is met.
+     *
+     * @example
+     * ```ts
+     * expect(["Bryce", "Bryan"]).to.all(it => startsWith(it, "Bry"));
+     * expect([1,3,4,5]).to.not.all(it => it % 2 === 0);
+     * ```
+     *
+     * @public
+     */
+    all(condition: Filter<InferArrayElement<T>>): this;
+
+    /**
+     * Asserts that all elements in the array satisfy the specified {@link Filter}.
+     *
+     * @param reason - A {@link Placeholder.reason | reason} to add at the end of the message for additional context.
+     * @param condition - A callback that returns `true` whenever the condition is met.
+     *
+     * @example
+     * ```ts
+     * expect(["Bryce", "Bryan"]).to.all('start with "Bry"', it => startsWith(it, "Bry"));
+     * expect([1,3,4,5]).to.not.all('be even', it => it % 2 === 0);
+     * ```
+     *
+     * Example message:
+     * ```logs
+     * Expected '[1,2,3]' to all be even, but there was an element that failed the check
+     *
+     * Index: 1
+     * Value: '1'
+     * ```
+     *
+     * @public
+     */
+    all(reason: string, condition: Filter<InferArrayElement<T>>): this;
+  }
+}
+
+extendMethods({
+  all: all,
+});

--- a/src/expect/extensions/finite/index.spec.ts
+++ b/src/expect/extensions/finite/index.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("finite", () => {
+    it("checks if value is within math.huge", () => {
+      expect(5).to.be.finite();
+      expect(-5).to.be.finite();
+      expect(0).to.be.finite();
+
+      expect(math.huge).to.not.be.finite();
+      expect(-math.huge).to.not.be.finite();
+    });
+
+    it("checks if value is a number", () => {
+      expect("5").to.not.be.finite();
+      expect(undefined).to.not.be.finite();
+      expect([1, 2, 3]).to.not.be.finite();
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the check fails", () => {
+      err(() => {
+        expect(math.huge).to.be.finite();
+      }, "Expected 'inf' to be a finite number, but it was 'math.huge'");
+
+      err(() => {
+        expect(-math.huge).to.be.finite();
+      }, "Expected '-inf' to be a finite number, but it was '-math.huge'");
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.be.finite();
+      }, "Expected the value to be a finite number, but it was undefined");
+    });
+
+    it("throws when it's not a number", () => {
+      err(() => {
+        expect("5").to.be.finite();
+      }, `Expected "5" (string) to be a finite number, but it wasn't a number`);
+
+      err(() => {
+        expect("5").to.be.finite();
+      }, `Expected "5" (string) to be a finite number, but it wasn't a number`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent?.name).to.be.finite();
+          });
+        },
+        `Expected parent.name to be a finite number, but it wasn't a number`,
+        `parent.name: "Daymon"`
+      );
+    });
+  });
+};

--- a/src/expect/extensions/finite/index.ts
+++ b/src/expect/extensions/finite/index.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} be a finite number`
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .negationSuffix(", but it was")
+  .nestedMetadata({
+    [place.path]: place.actual.value,
+  });
+
+const finite: CustomMethodImpl = (_, actual) => {
+  const message = baseMessage.use();
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "number")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a number");
+  }
+
+  if (math.huge === actual) {
+    return message.failWithReason("was 'math.huge'");
+  }
+
+  if (-math.huge === actual) {
+    return message.failWithReason("was '-math.huge'");
+  }
+
+  return message.pass();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the actual value is a number within `+-math.huge`.
+     *
+     * @remarks
+     * This comparison is exclusive, meaning a number that is `math.huge` or
+     * `-math.huge` is considered a fail.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.finite();
+     * expect(-5).to.be.finite();
+     *
+     * expect("5").to.not.be.finite();
+     * expect(math.huge).to.not.be.finite();
+     * ```
+     *
+     * @public
+     */
+    finite(): Assertion<number>;
+  }
+}
+
+extendMethods({
+  finite: finite,
+});

--- a/src/expect/extensions/index.spec.ts
+++ b/src/expect/extensions/index.spec.ts
@@ -17,4 +17,22 @@
 
 /// <reference types="@rbxts/testez/globals" />
 
-export = () => {};
+import { expect } from "@src/expect";
+import { err } from "@src/util";
+
+export = () => {
+  describe("expect", () => {
+    it("should override error messages", () => {
+      err(() => {
+        expect(5, "Your mom").to.be.undefined();
+      }, "Your mom");
+
+      err(() => {
+        expect(undefined, "Your mom").to.not.be.undefined();
+      }, "Your mom");
+
+      expect(5, "should not throw").to.be.defined();
+      expect(undefined, "should not throw").to.not.be.defined();
+    });
+  });
+};

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -26,6 +26,7 @@ import "./empty";
 import "./end-with";
 import "./enum";
 import "./even-odd";
+import "./finite";
 import "./include";
 import "./instance-of";
 import "./length";

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -36,6 +36,7 @@ import "./noops";
 import "./number-comparators";
 import "./pattern";
 import "./positive-negative";
+import "./satisfy";
 import "./shallow-equal";
 import "./some";
 import "./start-with";

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -29,6 +29,7 @@ import "./even-odd";
 import "./finite";
 import "./include";
 import "./instance-of";
+import "./key";
 import "./length";
 import "./match";
 import "./near";

--- a/src/expect/extensions/index.ts
+++ b/src/expect/extensions/index.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import "./all";
 import "./any-of";
 import "./array";
 import "./between";

--- a/src/expect/extensions/key/index.spec.ts
+++ b/src/expect/extensions/key/index.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+export = () => {
+  describe("key", () => {
+    it("looks for a key in the table", () => {
+      expect({ name: "daymon" })
+        .to.have.the.key("name")
+        .and.the.property("name")
+        .but.not.have.the.key("age");
+    });
+  });
+
+  describe("error message", () => {
+    it("throws when the key is missing", () => {
+      err(
+        () => {
+          expect(TEST_SON).to.have.the.key("child");
+        },
+        `Expected '{...}' to have the key "child", but it was missing`,
+        `Actual (full):`
+      );
+    });
+
+    it("adds the key value on negation", () => {
+      err(
+        () => {
+          expect(TEST_SON).to.not.have.the.key("name");
+        },
+        `Expected '{...}' to NOT have the key "name"`,
+        `name: "Kyle"`,
+        `Actual (full):`
+      );
+    });
+
+    it("throws when it's undefined", () => {
+      err(() => {
+        expect(undefined).to.have.the.key("name");
+      }, 'Expected the value to have the key "name", but it was undefined');
+    });
+
+    it("throws when it's not a table", () => {
+      err(() => {
+        expect(5).to.have.the.key("name");
+      }, `Expected '5' (number) to have the key "name", but it wasn't a table`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (son) => {
+            expect(son.parent).to.have.the.key("parent");
+          });
+        },
+        'Expected parent to have the key "parent", but it was missing',
+        "parent:"
+      );
+    });
+  });
+};

--- a/src/expect/extensions/key/index.ts
+++ b/src/expect/extensions/key/index.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Filter } from "@rbxts/expect";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} have the key ${place.expected.value}`
+)
+  .trailingFailureSuffix(`, but it ${place.reason}`)
+  .nestedMetadata({
+    [place.path]: `${place.actual.value} (${place.actual.type})`,
+  });
+
+const hasKey: CustomMethodImpl = (_, actual, key: string) => {
+  const message = baseMessage.use().expectedValue(key);
+
+  if (actual === undefined) {
+    return message.name("the value").failWithReason("was undefined");
+  }
+
+  if (!typeIs(actual, "table")) {
+    return message
+      .name(`${place.actual.value} (${place.actual.type})`)
+      .failWithReason("wasn't a table");
+  }
+
+  if (key in actual) {
+    return message
+      .metadata({
+        [`${key}`]: message.encode((actual as Record<string, unknown>)[key]),
+      })
+      .pass();
+  }
+
+  return message.failWithReason("was missing");
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the table has the key `key`.
+     *
+     * @param key - Name of the key that the table should have.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect({ name: "Daymon" }).to.have.the.key("name");
+     * ```
+     *
+     * @see {@link Assertion.property | property}
+     *
+     * @public
+     */
+    key(key: string): this;
+
+    /**
+     * Asserts that the table has the property `property`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.key | key}._
+     *
+     * @param property - Name of the property that the table should have.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect({ name: "Daymon" }).to.have.the.property("name");
+     * ```
+     *
+     * @public
+     */
+    property(property: string): this;
+  }
+}
+
+extendMethods({
+  key: hasKey,
+  property: hasKey,
+});

--- a/src/expect/extensions/satisfy/index.spec.ts
+++ b/src/expect/extensions/satisfy/index.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "@src/index";
+import { withProxy } from "@src/util/proxy";
+import { err, TEST_SON } from "@src/util/tests";
+
+function isString(it: unknown) {
+  return typeIs(it, "string");
+}
+
+export = () => {
+  describe("satisfy", () => {
+    it("passes when the callback returns true", () => {
+      expect(5)
+        .to.satisfy((it) => it === 5)
+        .but.not.satisfy((it) => it === undefined);
+    });
+  });
+
+  describe("error message", () => {
+    it("throws if the callback returns false", () => {
+      err(() => {
+        expect(5).to.satisfy(() => false);
+      }, `Expected '5' (number) to satisfy a given callback, but it didn't`);
+    });
+
+    it("uses named functions in the output", () => {
+      err(() => {
+        expect(5).to.satisfy(isString);
+      }, `Expected '5' (number) to satisfy isString, but it didn't`);
+    });
+
+    it("works with paths", () => {
+      err(
+        () => {
+          withProxy(TEST_SON, (proxy) => {
+            expect(proxy.parent?.age).to.satisfy(() => false);
+          });
+        },
+        `Expected parent.age to satisfy a given callback, but it didn't`,
+        "parent.age: '5' (number)"
+      );
+    });
+  });
+};

--- a/src/expect/extensions/satisfy/index.ts
+++ b/src/expect/extensions/satisfy/index.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2024 Daymon Littrell-Reyes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Filter } from "@rbxts/expect";
+import { CustomMethodImpl, extendMethods } from "@src/expect/extend";
+import { ExpectMessageBuilder } from "@src/message";
+import { place } from "@src/message/placeholders";
+
+const baseMessage = new ExpectMessageBuilder(
+  `Expected ${place.name} to ${place.not} satisfy `
+)
+  .name(`${place.actual.value} (${place.actual.type})`)
+  .nestedMetadata({
+    [place.path]: `${place.actual.value} (${place.actual.type})`,
+  });
+
+const satisfy: CustomMethodImpl = (_, actual, expected: Filter) => {
+  const maybeName = debug.info(expected, "n")[0] ?? "";
+  const name = maybeName !== "" ? maybeName : "a given callback";
+
+  const message = baseMessage.use(name);
+
+  const result = expected(actual);
+
+  return result
+    ? message.pass()
+    : message.trailingFailureSuffix(", but it didn't").fail();
+};
+
+declare module "@rbxts/expect" {
+  interface Assertion<T> {
+    /**
+     * Asserts that the value returns true for the given `filter`.
+     *
+     * @remarks
+     * If the passed `filter` is a named function, the function's name
+     * will be used in the failure messages.
+     *
+     * @param filter - Callback that returns true if the value passes.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.satisfy((it) => it >= 0);
+     * ```
+     *
+     * @public
+     */
+    satisfy(filter: Filter<T>): this;
+
+    /**
+     * Asserts that the value returns true for the given `filter`.
+     *
+     * @remarks
+     * _Type alias for {@link Assertion.satisfy | satisfy}._
+     *
+     * @param filter - Callback that returns true if the value passes.
+     *
+     * @returns This instance for chaining.
+     *
+     * @example
+     * ```ts
+     * expect(5).to.be.a.number().that.satisfies((it) => it >= 0);
+     * ```
+     *
+     * @public
+     */
+    satisfies(filter: Filter<T>): this;
+  }
+}
+
+extendMethods({
+  satisfy: satisfy,
+  satisfies: satisfy,
+});

--- a/wiki/docs/api/expect.assertion.all.md
+++ b/wiki/docs/api/expect.assertion.all.md
@@ -1,0 +1,64 @@
+---
+id: expect.assertion.all
+title: Assertion.all() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [all](./expect.assertion.all.md)
+
+## Assertion.all() method
+
+Asserts that all elements in the array satisfy the specified [Filter](./expect.filter.md)<!-- -->.
+
+**Signature:**
+
+```typescript
+all(condition: Filter<InferArrayElement<T>>): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+condition
+
+
+</td><td>
+
+[Filter](./expect.filter.md)<!-- -->&lt;[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;&gt;
+
+
+</td><td>
+
+A callback that returns `true` whenever the condition is met.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect(["Bryce", "Bryan"]).to.all(it => startsWith(it, "Bry"));
+expect([1,3,4,5]).to.not.all(it => it % 2 === 0);
+```

--- a/wiki/docs/api/expect.assertion.all_1.md
+++ b/wiki/docs/api/expect.assertion.all_1.md
@@ -1,0 +1,88 @@
+---
+id: expect.assertion.all_1
+title: Assertion.all() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [all](./expect.assertion.all_1.md)
+
+## Assertion.all() method
+
+Asserts that all elements in the array satisfy the specified [Filter](./expect.filter.md)<!-- -->.
+
+**Signature:**
+
+```typescript
+all(reason: string, condition: Filter<InferArrayElement<T>>): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+reason
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+A [reason](./expect.placeholder.reason.md) to add at the end of the message for additional context.
+
+
+</td></tr>
+<tr><td>
+
+condition
+
+
+</td><td>
+
+[Filter](./expect.filter.md)<!-- -->&lt;[InferArrayElement](./expect.inferarrayelement.md)<!-- -->&lt;T&gt;&gt;
+
+
+</td><td>
+
+A callback that returns `true` whenever the condition is met.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+## Example
+
+
+```ts
+expect(["Bryce", "Bryan"]).to.all('start with "Bry"', it => startsWith(it, "Bry"));
+expect([1,3,4,5]).to.not.all('be even', it => it % 2 === 0);
+```
+Example message:
+
+```logs
+Expected '[1,2,3]' to all be even, but there was an element that failed the check
+
+Index: 1
+Value: '1'
+```

--- a/wiki/docs/api/expect.assertion.finite.md
+++ b/wiki/docs/api/expect.assertion.finite.md
@@ -1,0 +1,35 @@
+---
+id: expect.assertion.finite
+title: Assertion.finite() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [finite](./expect.assertion.finite.md)
+
+## Assertion.finite() method
+
+Asserts that the actual value is a number within `+-math.huge`<!-- -->.
+
+**Signature:**
+
+```typescript
+finite(): Assertion<number>;
+```
+**Returns:**
+
+[Assertion](./expect.assertion.md)<!-- -->&lt;number&gt;
+
+## Remarks
+
+This comparison is exclusive, meaning a number that is `math.huge` or `-math.huge` is considered a fail.
+
+## Example
+
+
+```ts
+expect(5).to.be.finite();
+expect(-5).to.be.finite();
+
+expect("5").to.not.be.finite();
+expect(math.huge).to.not.be.finite();
+```

--- a/wiki/docs/api/expect.assertion.key.md
+++ b/wiki/docs/api/expect.assertion.key.md
@@ -1,0 +1,65 @@
+---
+id: expect.assertion.key
+title: Assertion.key() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [key](./expect.assertion.key.md)
+
+## Assertion.key() method
+
+Asserts that the table has the key `key`<!-- -->.
+
+**Signature:**
+
+```typescript
+key(key: string): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+key
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+Name of the key that the table should have.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Example
+
+
+```ts
+expect({ name: "Daymon" }).to.have.the.key("name");
+```

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -1343,6 +1343,28 @@ Asserts that the value is a positive number.
 </td></tr>
 <tr><td>
 
+[satisfies(filter)](./expect.assertion.satisfies.md)
+
+
+</td><td>
+
+Asserts that the value returns true for the given `filter`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[satisfy(filter)](./expect.assertion.satisfy.md)
+
+
+</td><td>
+
+Asserts that the value returns true for the given `filter`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [shallowEqual(expectedValue)](./expect.assertion.shallowequal.md)
 
 

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -980,6 +980,17 @@ Asserts that the value is a "falsy" value, according to luau.
 </td></tr>
 <tr><td>
 
+[finite()](./expect.assertion.finite.md)
+
+
+</td><td>
+
+Asserts that the actual value is a number within `+-math.huge`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [function()](./expect.assertion.function.md)
 
 

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -573,6 +573,28 @@ Asserts that the value is greater than `value`<!-- -->.
 </td></tr>
 <tr><td>
 
+[all(condition)](./expect.assertion.all.md)
+
+
+</td><td>
+
+Asserts that all elements in the array satisfy the specified [Filter](./expect.filter.md)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
+[all(reason, condition)](./expect.assertion.all_1.md)
+
+
+</td><td>
+
+Asserts that all elements in the array satisfy the specified [Filter](./expect.filter.md)<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [anyOf(values)](./expect.assertion.anyof.md)
 
 

--- a/wiki/docs/api/expect.assertion.md
+++ b/wiki/docs/api/expect.assertion.md
@@ -1101,6 +1101,17 @@ Asserts that the value is an instance of `I`<!-- -->, according to a provided [t
 </td></tr>
 <tr><td>
 
+[key(key)](./expect.assertion.key.md)
+
+
+</td><td>
+
+Asserts that the table has the key `key`<!-- -->.
+
+
+</td></tr>
+<tr><td>
+
 [least(value)](./expect.assertion.least.md)
 
 
@@ -1349,6 +1360,17 @@ Asserts that the `expectedValue` is a string that contains a match for the provi
 </td><td>
 
 Asserts that the value is a positive number.
+
+
+</td></tr>
+<tr><td>
+
+[property(property)](./expect.assertion.property.md)
+
+
+</td><td>
+
+Asserts that the table has the property `property`<!-- -->.
 
 
 </td></tr>

--- a/wiki/docs/api/expect.assertion.property.md
+++ b/wiki/docs/api/expect.assertion.property.md
@@ -1,0 +1,69 @@
+---
+id: expect.assertion.property
+title: Assertion.property() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [property](./expect.assertion.property.md)
+
+## Assertion.property() method
+
+Asserts that the table has the property `property`<!-- -->.
+
+**Signature:**
+
+```typescript
+property(property: string): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+property
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+Name of the property that the table should have.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Remarks
+
+_Type alias for [key](./expect.assertion.key.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect({ name: "Daymon" }).to.have.the.property("name");
+```

--- a/wiki/docs/api/expect.assertion.satisfies.md
+++ b/wiki/docs/api/expect.assertion.satisfies.md
@@ -1,0 +1,69 @@
+---
+id: expect.assertion.satisfies
+title: Assertion.satisfies() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [satisfies](./expect.assertion.satisfies.md)
+
+## Assertion.satisfies() method
+
+Asserts that the value returns true for the given `filter`<!-- -->.
+
+**Signature:**
+
+```typescript
+satisfies(filter: Filter<T>): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+filter
+
+
+</td><td>
+
+[Filter](./expect.filter.md)<!-- -->&lt;T&gt;
+
+
+</td><td>
+
+Callback that returns true if the value passes.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Remarks
+
+_Type alias for [satisfy](./expect.assertion.satisfy.md)<!-- -->._
+
+## Example
+
+
+```ts
+expect(5).to.be.a.number().that.satisfies((it) => it >= 0);
+```

--- a/wiki/docs/api/expect.assertion.satisfy.md
+++ b/wiki/docs/api/expect.assertion.satisfy.md
@@ -1,0 +1,69 @@
+---
+id: expect.assertion.satisfy
+title: Assertion.satisfy() method
+hide_title: true
+---
+
+[@rbxts/expect](./expect.md) &gt; [Assertion](./expect.assertion.md) &gt; [satisfy](./expect.assertion.satisfy.md)
+
+## Assertion.satisfy() method
+
+Asserts that the value returns true for the given `filter`<!-- -->.
+
+**Signature:**
+
+```typescript
+satisfy(filter: Filter<T>): this;
+```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+filter
+
+
+</td><td>
+
+[Filter](./expect.filter.md)<!-- -->&lt;T&gt;
+
+
+</td><td>
+
+Callback that returns true if the value passes.
+
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+this
+
+This instance for chaining.
+
+## Remarks
+
+If the passed `filter` is a named function, the function's name will be used in the failure messages.
+
+## Example
+
+
+```ts
+expect(5).to.satisfy((it) => it >= 0);
+```

--- a/wiki/docs/api/expect.expect.md
+++ b/wiki/docs/api/expect.expect.md
@@ -13,7 +13,7 @@ Perform assertions/checks on the state of a value.
 **Signature:**
 
 ```typescript
-declare function expect<T>(value: T): Assertion<T>;
+declare function expect<T>(value: T, customMessage?: string): Assertion<T>;
 ```
 
 ## Parameters
@@ -50,6 +50,22 @@ The "actual" value to perform checks against.
 
 
 </td></tr>
+<tr><td>
+
+customMessage
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+_(Optional)_ A custom message to use if the check fails; replaces whatever message expect throws.
+
+
+</td></tr>
 </tbody></table>
 **Returns:**
 
@@ -65,7 +81,7 @@ You can then use the instance returned by `expect` to make various "assertions" 
 
 For a full list of available checks, take a look at the [API](https://rbxts-expect.daymxn.com/docs/api).
 
-## Example
+## Example 1
 
 
 ```ts
@@ -76,4 +92,12 @@ expect("Daymon").to.have.the.substring("Day");
 expect([1,2,3]).to.include(1).but.not.include(4);
 
 expect(Sport.Basketball).to.be.the.enum(Sport).and.to.be.oneOf(["Basketball", "Soccer"]);
+```
+
+## Example 2
+
+Using a custom message
+
+```ts
+expect(player.money, "You don't have enough money").to.be.gte(pet.cost);
 ```

--- a/wiki/docs/api/expect.md
+++ b/wiki/docs/api/expect.md
@@ -89,7 +89,7 @@ Throws an error if the `callback` doesn't throw.
 </td></tr>
 <tr><td>
 
-[expect(value)](./expect.expect.md)
+[expect(value, customMessage)](./expect.expect.md)
 
 
 </td><td>

--- a/wiki/docs/matchers/arrays.mdx
+++ b/wiki/docs/matchers/arrays.mdx
@@ -190,6 +190,27 @@ Missing: '[1,2]'
 
 :::
 
+### All
+
+You can use the [all](/docs/api/expect.assertion.all.md) method to check if all the elments in an array pass some
+condition.
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect([2, 4, 6]).to.all((it) => it % 2 === 0);
+expect(["Bryce", "Bryan"]).to.all(`start with "Bry"`, (it) => startsWith(it, "Bry"));
+```
+
+#### Example error
+
+```logs
+Expected '["Bryce", "Bryan", "Daymon"]' to all start with "Bry", but there was an element that failed the check
+
+Index: 3
+Value: "Daymon"
+```
+
 ### Some
 
 You can use the [some](/docs/api/expect.assertion.some.md) method to check if an array passes some condition.

--- a/wiki/docs/matchers/arrays.mdx
+++ b/wiki/docs/matchers/arrays.mdx
@@ -166,30 +166,6 @@ Expected '[1,2,3,4]' to be an array that ends with '[1,2,4]', but it was missing
 Missing: '[1,2]'
 ```
 
-### All of
-
-:::info
-
-[GitHub Issue #14](https://github.com/daymxn/rbxts-expect/issues/14)
-
-:::
-
-### Unique
-
-:::info
-
-[GitHub Issue #13](https://github.com/daymxn/rbxts-expect/issues/13)
-
-:::
-
-### Sorted
-
-:::info
-
-[GitHub Issue #2](https://github.com/daymxn/rbxts-expect/issues/2)
-
-:::
-
 ### All
 
 You can use the [all](/docs/api/expect.assertion.all.md) method to check if all the elments in an array pass some
@@ -266,3 +242,27 @@ Expected '[1,2,3]' to contain exactly '[1,3,2]', but it had a different value fo
 Expected [1]: '3'
 Actual [1]: '2'
 ```
+
+### All of
+
+:::info
+
+[GitHub Issue #14](https://github.com/daymxn/rbxts-expect/issues/14)
+
+:::
+
+### Unique
+
+:::info
+
+[GitHub Issue #13](https://github.com/daymxn/rbxts-expect/issues/13)
+
+:::
+
+### Sorted
+
+:::info
+
+[GitHub Issue #2](https://github.com/daymxn/rbxts-expect/issues/2)
+
+:::

--- a/wiki/docs/matchers/basic.mdx
+++ b/wiki/docs/matchers/basic.mdx
@@ -71,11 +71,20 @@ Expected '5' to be of type 'string', but it was a 'number'
 
 ### Satisfy
 
-:::info
+You can use the [satisfy](/docs/api/expect.assertion.satisfy.md) method to check if a provided value passes a given
+callback.
 
-[GitHub Issue #5](https://github.com/daymxn/rbxts-expect/issues/5)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect(4).to.satisfy((value) => 4 % 2 === 0);
+```
+
+#### Example error
+
+```logs
+Expected '5' (number) to satisfy a given callback, but it didn't
+```
 
 ### Defined
 

--- a/wiki/docs/matchers/numbers.mdx
+++ b/wiki/docs/matchers/numbers.mdx
@@ -176,11 +176,23 @@ Expected '10' to be a number between 5 and 8, but it was too high.
 
 ### Finite
 
-:::info
+You can use the [finite](/docs/api/expect.assertion.finite.md) method to check if a number is within `+-math.huge`
 
-[GitHub Issue #10](https://github.com/daymxn/rbxts-expect/issues/10)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect(5).to.be.finite();
+expect(-5).to.be.finite();
+
+expect("5").to.not.be.finite();
+expect(math.huge).to.not.be.finite();
+```
+
+#### Example error
+
+```logs
+Expected 'inf' to be a finite number, but it was 'math.huge'
+```
 
 ### Near
 

--- a/wiki/docs/matchers/objects.mdx
+++ b/wiki/docs/matchers/objects.mdx
@@ -122,11 +122,25 @@ Actual (full): '{"name":"Daymon","age":5}'
 
 ### Key/Property
 
-:::info
+You can use the [key](/docs/api/expect.assertion.key.md) or [property](/docs/api/expect.assertion.property.md) methods
+to check if an object has a certina key.
 
-[GitHub Issue #20](https://github.com/daymxn/rbxts-expect/issues/20)
+```ts
+import { expect } from "@rbxts/expect";
 
-:::
+expect({
+  name: "Daymon",
+  age: 5,
+}).to.have.the.key("name");
+```
+
+#### Example error
+
+```logs
+Expected '{...}' to have the key "parent", but it was missing
+
+Actual (full): '{"name":"Daymon","age":5}'
+```
 
 ## Extra
 

--- a/wiki/docs/quick-start.mdx
+++ b/wiki/docs/quick-start.mdx
@@ -175,6 +175,18 @@ Expected (full): '{"child":{"name":"rigby","age":5},"name":"daymon","age":24}'
 Actual (full): '{"child":{"name":"nova","age":5},"name":"daymon","age":24}'
 ```
 
+### Custom messages
+
+```ts
+import { expect } from "@rbxts/expect";
+
+expect(5, "You don't have enough money!").to.be.gte(10);
+```
+
+```logs title="Console"
+You don't have enough money!
+```
+
 ## Next steps
 
 If you're wanting to learn more, feel free to check out any of the following resources:

--- a/wiki/docs/usage-guide.mdx
+++ b/wiki/docs/usage-guide.mdx
@@ -188,15 +188,11 @@ remotes.purchasePet.connect(async (player, petId) => {
 });
 ```
 
-Although, if you want to transform your messages in a different way than what `@rbxts/expect` outputs, it's your job to
-catch the exception and rethrow it accordingly.
+You can also provide your own override for the message failure by providing a string as the second argument to
+[expect](/docs/api/expect.expect.md).
 
 ```ts
-try {
-  expect(data.money).to.be.gte(pet.cost);
-} catch (e) {
-  throw "You don't have enough money!";
-}
+expect(data.money, "You don't have enough money!").to.be.gte(pet.cost);
 ```
 
 ## Client usage


### PR DESCRIPTION
Contains the matchers `satisfy`, `finite`, `all`, `key`, and `property`. Also includes support for message overrides.

Fixes #20 
Fixes #10 
Fixes #41 
Fixes #5 
Fixes #42 