### PR TITLE
Fix keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 			"only": true
 		}
 	},
-	"keywords": [],
+	"keywords": ["rbxts", "expect", "test", "assertion", "typescript", "roblox"],
 	"author": "Daymon Littrell-Reyes",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
The keywords block in `package.json` was empty. This updates it to not be.